### PR TITLE
Lockable pipes

### DIFF
--- a/src/main/java/com/drmangotea/tfmg/content/decoration/pipes/ILockablePipe.java
+++ b/src/main/java/com/drmangotea/tfmg/content/decoration/pipes/ILockablePipe.java
@@ -1,0 +1,46 @@
+package com.drmangotea.tfmg.content.decoration.pipes;
+
+import com.simibubi.create.AllBlocks;
+import com.simibubi.create.content.fluids.FluidTransportBehaviour;
+import com.simibubi.create.content.fluids.pipes.FluidPipeBlock;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.sounds.SoundEvents;
+import net.minecraft.sounds.SoundSource;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.LevelAccessor;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.block.state.properties.BlockStateProperties;
+import net.minecraft.world.level.block.state.properties.BooleanProperty;
+
+import java.util.Map;
+
+public interface ILockablePipe {
+
+    boolean locked();
+    void setLocked(boolean locked);
+
+    default void toggleLock(Player player, Level world, BlockPos pos, BlockState state) {
+        world.playSound(player, pos, SoundEvents.ITEM_PICKUP, SoundSource.BLOCKS, 0.4f, 0.5f);
+
+        setLocked(!locked());
+        if (locked())
+            return;
+
+        BlockState newState;
+        FluidTransportBehaviour.cacheFlows(world, pos);
+        newState = updatePipe(world, pos, state).setValue(BlockStateProperties.WATERLOGGED, state.getValue(BlockStateProperties.WATERLOGGED));
+        world.setBlock(pos, newState, 3);
+        FluidTransportBehaviour.loadFlows(world, pos);
+    }
+
+    default BlockState updatePipe(LevelAccessor world, BlockPos pos, BlockState state) {
+        Direction side = Direction.UP;
+        Map<Direction, BooleanProperty> facingToPropertyMap = FluidPipeBlock.PROPERTY_BY_DIRECTION;
+        return AllBlocks.FLUID_PIPE.get()
+                .updateBlockState(state.getBlock().defaultBlockState()
+                        .setValue(facingToPropertyMap.get(side), true)
+                        .setValue(facingToPropertyMap.get(side.getOpposite()), true), side, null, world, pos);
+    }
+}

--- a/src/main/java/com/drmangotea/tfmg/content/decoration/pipes/TFMGEncasedPipeBlock.java
+++ b/src/main/java/com/drmangotea/tfmg/content/decoration/pipes/TFMGEncasedPipeBlock.java
@@ -30,10 +30,7 @@ public class TFMGEncasedPipeBlock extends EncasedPipeBlock {
         super(p_i48339_1_, casing);
         this.material = material;
     }
-    //@Override
-    //public ItemStack getCloneItemStack(BlockState state, HitResult target, BlockGetter world, BlockPos pos, Player player) {
-    //    return TFMGPipes.TFMG_PIPES.get(material).get(0).asStack();
-    //}
+
     @Override
     public InteractionResult onWrenched(BlockState state, UseOnContext context) {
         Level world = context.getLevel();

--- a/src/main/java/com/drmangotea/tfmg/content/decoration/pipes/TFMGGlassPipeBlock.java
+++ b/src/main/java/com/drmangotea/tfmg/content/decoration/pipes/TFMGGlassPipeBlock.java
@@ -40,12 +40,6 @@ public class TFMGGlassPipeBlock extends GlassFluidPipeBlock {
         return ItemRequirement.of(TFMGPipes.PIPES.get(material).getPipe().getDefaultState(), te);
     }
 
-   // @Override
-   // public ItemStack getCloneItemStack(BlockState state, HitResult target, BlockGetter world, BlockPos pos,
-   //                                    Player player) {
-   //     return TFMGPipes.TFMG_PIPES.get(material).get(0).asStack();
-   // }
-
     @Override
     public BlockState toRegularPipe(LevelAccessor world, BlockPos pos, BlockState state) {
         Direction side = Direction.get(Direction.AxisDirection.POSITIVE, state.getValue(AXIS));

--- a/src/main/java/com/drmangotea/tfmg/content/decoration/pipes/TFMGPipeBlock.java
+++ b/src/main/java/com/drmangotea/tfmg/content/decoration/pipes/TFMGPipeBlock.java
@@ -43,10 +43,9 @@ public class TFMGPipeBlock extends FluidPipeBlock {
         this.material = material;
     }
 
-    public BlockState updateBlockState(BlockState state, Direction preferredDirection, @Nullable Direction ignore,
-                                       BlockAndTintGetter world, BlockPos pos) {
-        if (world.getBlockEntity(pos) instanceof TFMGPipeBlockEntity)
-            if (((TFMGPipeBlockEntity) world.getBlockEntity(pos)).locked) {
+    public BlockState updateBlockState(BlockState state, Direction preferredDirection, @Nullable Direction ignore, BlockAndTintGetter world, BlockPos pos) {
+        if (world.getBlockEntity(pos) instanceof ILockablePipe lockablePipe)
+            if (lockablePipe.locked()) {
                 return state;
             }
 
@@ -65,8 +64,8 @@ public class TFMGPipeBlock extends FluidPipeBlock {
             if (d != ignore) {
                 boolean shouldConnect = canConnectTo(world, pos.relative(d), world.getBlockState(pos.relative(d)), d);
 
-                if (world.getBlockEntity(pos.relative(d)) instanceof TFMGPipeBlockEntity) {
-                    if (((TFMGPipeBlockEntity) world.getBlockEntity(pos.relative(d))).locked) {
+                if (world.getBlockEntity(pos.relative(d)) instanceof ILockablePipe lockablePipe) {
+                    if (lockablePipe.locked()) {
                         shouldConnect = false;
                         if (world.getBlockState(pos.relative(d)).getValue(PROPERTY_BY_DIRECTION.get(d.getOpposite()))) {
                             shouldConnect = true;

--- a/src/main/java/com/drmangotea/tfmg/content/decoration/pipes/TFMGPipeBlock.java
+++ b/src/main/java/com/drmangotea/tfmg/content/decoration/pipes/TFMGPipeBlock.java
@@ -43,62 +43,6 @@ public class TFMGPipeBlock extends FluidPipeBlock {
         this.material = material;
     }
 
-    public BlockState updateBlockState(BlockState state, Direction preferredDirection, @Nullable Direction ignore, BlockAndTintGetter world, BlockPos pos) {
-        if (world.getBlockEntity(pos) instanceof ILockablePipe lockablePipe)
-            if (lockablePipe.locked()) {
-                return state;
-            }
-
-        BracketedBlockEntityBehaviour bracket = BlockEntityBehaviour.get(world, pos, BracketedBlockEntityBehaviour.TYPE);
-        if (bracket != null && bracket.isBracketPresent())
-            return state;
-
-        BlockState prevState = state;
-        int prevStateSides = (int) Arrays.stream(Iterate.directions)
-                .map(PROPERTY_BY_DIRECTION::get)
-                .filter(prevState::getValue)
-                .count();
-
-        // Update sides that are not ignored
-        for (Direction d : Iterate.directions)
-            if (d != ignore) {
-                boolean shouldConnect = canConnectTo(world, pos.relative(d), world.getBlockState(pos.relative(d)), d);
-
-                if (world.getBlockEntity(pos.relative(d)) instanceof ILockablePipe lockablePipe) {
-                    if (lockablePipe.locked()) {
-                        shouldConnect = false;
-                        if (world.getBlockState(pos.relative(d)).getValue(PROPERTY_BY_DIRECTION.get(d.getOpposite()))) {
-                            shouldConnect = true;
-                        }
-                    }
-
-
-                }
-                state = state.setValue(PROPERTY_BY_DIRECTION.get(d), shouldConnect);
-            }
-
-        // See if it has enough connections
-        Direction connectedDirection = null;
-        for (Direction d : Iterate.directions) {
-            if (isOpenAt(state, d)) {
-                if (connectedDirection != null)
-                    return state;
-                connectedDirection = d;
-            }
-        }
-        // Add opposite end if only one connection
-        if (connectedDirection != null)
-            return state.setValue(PROPERTY_BY_DIRECTION.get(connectedDirection.getOpposite()), true);
-
-        // If we can't connect to anything and weren't connected before, do nothing
-        if (prevStateSides == 2)
-            return prevState;
-
-        // Use preferred
-        return state.setValue(PROPERTY_BY_DIRECTION.get(preferredDirection), true)
-                .setValue(PROPERTY_BY_DIRECTION.get(preferredDirection.getOpposite()), true);
-    }
-
     @Override
     public void tick(BlockState state, ServerLevel world, BlockPos pos, RandomSource r) {
         super.tick(state, world, pos, r);
@@ -106,8 +50,6 @@ public class TFMGPipeBlock extends FluidPipeBlock {
 
     @Override
     public InteractionResult onWrenched(BlockState state, UseOnContext context) {
-
-
         if (tryRemoveBracket(context))
             return InteractionResult.SUCCESS;
         Level world = context.getLevel();
@@ -155,12 +97,6 @@ public class TFMGPipeBlock extends FluidPipeBlock {
     private Direction.Axis getAxis(BlockGetter world, BlockPos pos, BlockState state) {
         return FluidPropagator.getStraightPipeAxis(state);
     }
-
-    //@Override
-    //public ItemStack getCloneItemStack(BlockState state, HitResult target, BlockGetter world, BlockPos pos,
-    //                                   Player player) {
-    //    return TFMGPipes.TFMG_PIPES.get(material).get(0).asStack();
-    //}
 
     @Override
     protected ItemInteractionResult useItemOn(ItemStack stack, BlockState state, Level world, BlockPos pos, Player player, InteractionHand hand, BlockHitResult hitResult) {

--- a/src/main/java/com/drmangotea/tfmg/content/decoration/pipes/TFMGPipeBlockEntity.java
+++ b/src/main/java/com/drmangotea/tfmg/content/decoration/pipes/TFMGPipeBlockEntity.java
@@ -23,45 +23,43 @@ import java.util.Map;
 
 public class TFMGPipeBlockEntity extends FluidPipeBlockEntity {
 
-    public boolean locked = false;
+    //public boolean locked = false;
     public TFMGPipeBlockEntity(BlockEntityType<?> type, BlockPos pos, BlockState state) {
         super(type, pos, state);
     }
 
-    public void toggleLock(Player player) {
-        level.playSound(player, getBlockPos(), SoundEvents.ITEM_PICKUP, SoundSource.BLOCKS, 0.4f, 0.5f);
+    //public void toggleLock(Player player) {
+    //    level.playSound(player, getBlockPos(), SoundEvents.ITEM_PICKUP, SoundSource.BLOCKS, 0.4f, 0.5f);
+    //    locked = !locked;
+    //    if (locked)
+    //        return;
+    //    BlockState newState;
+    //    Level world = level;
+    //    BlockPos pos = getBlockPos();
+    //    FluidTransportBehaviour.cacheFlows(world, pos);
+    //    newState = updatePipe(world, pos, getBlockState()).setValue(BlockStateProperties.WATERLOGGED, getBlockState().getValue(BlockStateProperties.WATERLOGGED));
+    //    world.setBlock(pos, newState, 3);
+    //    FluidTransportBehaviour.loadFlows(world, pos);
+    //}
 
-        locked = !locked;
-        if (locked)
-            return;
-
-        BlockState newState;
-        Level world = level;
-        BlockPos pos = getBlockPos();
-        FluidTransportBehaviour.cacheFlows(world, pos);
-        newState = updatePipe(world, pos, getBlockState()).setValue(BlockStateProperties.WATERLOGGED, getBlockState().getValue(BlockStateProperties.WATERLOGGED));
-        world.setBlock(pos, newState, 3);
-        FluidTransportBehaviour.loadFlows(world, pos);
-    }
-
-    public BlockState updatePipe(LevelAccessor world, BlockPos pos, BlockState state) {
-        Direction side = Direction.UP;
-        Map<Direction, BooleanProperty> facingToPropertyMap = FluidPipeBlock.PROPERTY_BY_DIRECTION;
-        return AllBlocks.FLUID_PIPE.get()
-                .updateBlockState(state.getBlock().defaultBlockState()
-                        .setValue(facingToPropertyMap.get(side), true)
-                        .setValue(facingToPropertyMap.get(side.getOpposite()), true), side, null, world, pos);
-    }
+    //public BlockState updatePipe(LevelAccessor world, BlockPos pos, BlockState state) {
+    //    Direction side = Direction.UP;
+    //    Map<Direction, BooleanProperty> facingToPropertyMap = FluidPipeBlock.PROPERTY_BY_DIRECTION;
+    //    return AllBlocks.FLUID_PIPE.get()
+    //            .updateBlockState(state.getBlock().defaultBlockState()
+    //                    .setValue(facingToPropertyMap.get(side), true)
+    //                    .setValue(facingToPropertyMap.get(side.getOpposite()), true), side, null, world, pos);
+    //}
 
     @Override
     public void write(CompoundTag compound, HolderLookup.Provider registries, boolean clientPacket) {
-        compound.putBoolean("Locked", locked);
+        //compound.putBoolean("Locked", locked);
         super.write(compound,registries , clientPacket);
     }
 
     @Override
     protected void read(CompoundTag compound, HolderLookup.Provider registries, boolean clientPacket) {
         super.read(compound,registries , clientPacket);
-        locked = compound.getBoolean("Locked");
+        //locked = compound.getBoolean("Locked");
     }
 }

--- a/src/main/java/com/drmangotea/tfmg/content/decoration/pipes/TFMGPipeBlockEntity.java
+++ b/src/main/java/com/drmangotea/tfmg/content/decoration/pipes/TFMGPipeBlockEntity.java
@@ -1,65 +1,15 @@
 package com.drmangotea.tfmg.content.decoration.pipes;
 
 
-import com.simibubi.create.AllBlocks;
-import com.simibubi.create.content.fluids.FluidTransportBehaviour;
-import com.simibubi.create.content.fluids.pipes.FluidPipeBlock;
 import com.simibubi.create.content.fluids.pipes.FluidPipeBlockEntity;
 import net.minecraft.core.BlockPos;
-import net.minecraft.core.Direction;
-import net.minecraft.core.HolderLookup;
-import net.minecraft.nbt.CompoundTag;
-import net.minecraft.sounds.SoundEvents;
-import net.minecraft.sounds.SoundSource;
-import net.minecraft.world.entity.player.Player;
-import net.minecraft.world.level.Level;
-import net.minecraft.world.level.LevelAccessor;
 import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.block.state.BlockState;
-import net.minecraft.world.level.block.state.properties.BlockStateProperties;
-import net.minecraft.world.level.block.state.properties.BooleanProperty;
-
-import java.util.Map;
 
 public class TFMGPipeBlockEntity extends FluidPipeBlockEntity {
 
-    //public boolean locked = false;
     public TFMGPipeBlockEntity(BlockEntityType<?> type, BlockPos pos, BlockState state) {
         super(type, pos, state);
     }
 
-    //public void toggleLock(Player player) {
-    //    level.playSound(player, getBlockPos(), SoundEvents.ITEM_PICKUP, SoundSource.BLOCKS, 0.4f, 0.5f);
-    //    locked = !locked;
-    //    if (locked)
-    //        return;
-    //    BlockState newState;
-    //    Level world = level;
-    //    BlockPos pos = getBlockPos();
-    //    FluidTransportBehaviour.cacheFlows(world, pos);
-    //    newState = updatePipe(world, pos, getBlockState()).setValue(BlockStateProperties.WATERLOGGED, getBlockState().getValue(BlockStateProperties.WATERLOGGED));
-    //    world.setBlock(pos, newState, 3);
-    //    FluidTransportBehaviour.loadFlows(world, pos);
-    //}
-
-    //public BlockState updatePipe(LevelAccessor world, BlockPos pos, BlockState state) {
-    //    Direction side = Direction.UP;
-    //    Map<Direction, BooleanProperty> facingToPropertyMap = FluidPipeBlock.PROPERTY_BY_DIRECTION;
-    //    return AllBlocks.FLUID_PIPE.get()
-    //            .updateBlockState(state.getBlock().defaultBlockState()
-    //                    .setValue(facingToPropertyMap.get(side), true)
-    //                    .setValue(facingToPropertyMap.get(side.getOpposite()), true), side, null, world, pos);
-    //}
-
-    @Override
-    public void write(CompoundTag compound, HolderLookup.Provider registries, boolean clientPacket) {
-        //compound.putBoolean("Locked", locked);
-        super.write(compound,registries , clientPacket);
-    }
-
-    @Override
-    protected void read(CompoundTag compound, HolderLookup.Provider registries, boolean clientPacket) {
-        super.read(compound,registries , clientPacket);
-        //locked = compound.getBoolean("Locked");
-    }
 }

--- a/src/main/java/com/drmangotea/tfmg/content/items/ScrewdriverItem.java
+++ b/src/main/java/com/drmangotea/tfmg/content/items/ScrewdriverItem.java
@@ -1,7 +1,6 @@
 package com.drmangotea.tfmg.content.items;
 
 import com.drmangotea.tfmg.content.decoration.pipes.ILockablePipe;
-import com.drmangotea.tfmg.content.decoration.pipes.TFMGPipeBlockEntity;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.entity.LivingEntity;
@@ -12,27 +11,20 @@ import net.minecraft.world.level.Level;
 
 
 public class ScrewdriverItem extends Item {
-    public ScrewdriverItem(Properties p_40566_) {
-        super( p_40566_);
-
+    public ScrewdriverItem(Properties properties) {
+        super(properties);
     }
+
     @Override
     public InteractionResult useOn(UseOnContext pContext) {
         Player player = pContext.getPlayer();
         BlockPos positionClicked = pContext.getClickedPos();
         Level level = pContext.getLevel();
 
-        if (level.getBlockEntity(positionClicked) != null) {
-            //if (level.getBlockEntity(positionClicked) instanceof TFMGPipeBlockEntity pipeBlockEntity) {
-            //    pipeBlockEntity.toggleLock(player);
-            //    pContext.getItemInHand().hurtAndBreak(1, pContext.getPlayer(),
-            //            LivingEntity.getSlotForHand(pContext.getHand()));
-            //    return InteractionResult.SUCCESS;
-            //}
+        if (level.getBlockEntity(positionClicked) != null && player != null) {
             if (level.getBlockEntity(positionClicked) instanceof ILockablePipe lockablePipe) {
                 lockablePipe.toggleLock(player, level, positionClicked, level.getBlockState(positionClicked));
-                pContext.getItemInHand().hurtAndBreak(1, pContext.getPlayer(),
-                        LivingEntity.getSlotForHand(pContext.getHand()));
+                pContext.getItemInHand().hurtAndBreak(1, player, LivingEntity.getSlotForHand(pContext.getHand()));
                 return InteractionResult.SUCCESS;
             }
         }

--- a/src/main/java/com/drmangotea/tfmg/content/items/ScrewdriverItem.java
+++ b/src/main/java/com/drmangotea/tfmg/content/items/ScrewdriverItem.java
@@ -1,5 +1,6 @@
 package com.drmangotea.tfmg.content.items;
 
+import com.drmangotea.tfmg.content.decoration.pipes.ILockablePipe;
 import com.drmangotea.tfmg.content.decoration.pipes.TFMGPipeBlockEntity;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.InteractionResult;
@@ -18,18 +19,23 @@ public class ScrewdriverItem extends Item {
     @Override
     public InteractionResult useOn(UseOnContext pContext) {
         Player player = pContext.getPlayer();
-
         BlockPos positionClicked = pContext.getClickedPos();
-
         Level level = pContext.getLevel();
 
-        if (level.getBlockEntity(positionClicked) != null && level.getBlockEntity(positionClicked) instanceof TFMGPipeBlockEntity pipeBlockEntity) {
-            pipeBlockEntity.toggleLock(player);
-            pContext.getItemInHand().hurtAndBreak(1, pContext.getPlayer(),
-                    LivingEntity.getSlotForHand(pContext.getHand()));
-            return InteractionResult.SUCCESS;
-        } else {
-            return super.useOn(pContext);
+        if (level.getBlockEntity(positionClicked) != null) {
+            //if (level.getBlockEntity(positionClicked) instanceof TFMGPipeBlockEntity pipeBlockEntity) {
+            //    pipeBlockEntity.toggleLock(player);
+            //    pContext.getItemInHand().hurtAndBreak(1, pContext.getPlayer(),
+            //            LivingEntity.getSlotForHand(pContext.getHand()));
+            //    return InteractionResult.SUCCESS;
+            //}
+            if (level.getBlockEntity(positionClicked) instanceof ILockablePipe lockablePipe) {
+                lockablePipe.toggleLock(player, level, positionClicked, level.getBlockState(positionClicked));
+                pContext.getItemInHand().hurtAndBreak(1, pContext.getPlayer(),
+                        LivingEntity.getSlotForHand(pContext.getHand()));
+                return InteractionResult.SUCCESS;
+            }
         }
+        return super.useOn(pContext);
     }
 }

--- a/src/main/java/com/drmangotea/tfmg/mixin/FluidPipeBlockEntityMixin.java
+++ b/src/main/java/com/drmangotea/tfmg/mixin/FluidPipeBlockEntityMixin.java
@@ -1,0 +1,45 @@
+package com.drmangotea.tfmg.mixin;
+
+import com.drmangotea.tfmg.content.decoration.pipes.ILockablePipe;
+import com.simibubi.create.content.fluids.pipes.FluidPipeBlockEntity;
+import com.simibubi.create.foundation.blockEntity.SmartBlockEntity;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.HolderLookup;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.world.level.block.entity.BlockEntityType;
+import net.minecraft.world.level.block.state.BlockState;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+
+@SuppressWarnings("AddedMixinMembersNamePattern")
+@Mixin(FluidPipeBlockEntity.class)
+public abstract class FluidPipeBlockEntityMixin extends SmartBlockEntity implements ILockablePipe {
+    @Unique
+    private boolean tfmg$locked = false;
+
+    public FluidPipeBlockEntityMixin(BlockEntityType<?> type, BlockPos pos, BlockState state) {
+        super(type, pos, state);
+    }
+
+    @Override
+    public boolean locked() {
+        return tfmg$locked;
+    }
+
+    @Override
+    public void setLocked(boolean locked) {
+        tfmg$locked = locked;
+    }
+
+    @Override
+    public void write(CompoundTag compound, HolderLookup.Provider registries, boolean clientPacket) {
+        compound.putBoolean("Locked", tfmg$locked);
+        super.write(compound,registries , clientPacket);
+    }
+
+    @Override
+    protected void read(CompoundTag compound, HolderLookup.Provider registries, boolean clientPacket) {
+        super.read(compound,registries , clientPacket);
+        tfmg$locked = compound.getBoolean("Locked");
+    }
+}

--- a/src/main/java/com/drmangotea/tfmg/mixin/FluidPipeBlockMixin.java
+++ b/src/main/java/com/drmangotea/tfmg/mixin/FluidPipeBlockMixin.java
@@ -1,5 +1,6 @@
 package com.drmangotea.tfmg.mixin;
 
+import com.drmangotea.tfmg.content.decoration.pipes.ILockablePipe;
 import com.drmangotea.tfmg.content.decoration.pipes.TFMGPipeBlockEntity;
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
@@ -24,12 +25,10 @@ public class FluidPipeBlockMixin {
 
 		BlockEntity be = world.getBlockEntity(neighbourPos);
 
-		if (be instanceof TFMGPipeBlockEntity tfmgPipe) {
-			if (tfmgPipe.locked) {
+		if (be instanceof ILockablePipe lockablePipe) {
+			if (lockablePipe.locked()) {
 				var oppositeProperty = FluidPipeBlock.PROPERTY_BY_DIRECTION.get(direction.getOpposite());
-				shouldConnect =
-					neighbourState.hasProperty(oppositeProperty) &&
-					neighbourState.getValue(oppositeProperty);
+				shouldConnect = neighbourState.hasProperty(oppositeProperty) && neighbourState.getValue(oppositeProperty);
 			}
 		}
 

--- a/src/main/java/com/drmangotea/tfmg/mixin/FluidPipeBlockMixin.java
+++ b/src/main/java/com/drmangotea/tfmg/mixin/FluidPipeBlockMixin.java
@@ -12,6 +12,8 @@ import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Mixin(FluidPipeBlock.class)
 public class FluidPipeBlockMixin {
@@ -22,9 +24,7 @@ public class FluidPipeBlockMixin {
 	)
 	private boolean tfmg$filterLockedPipes(BlockAndTintGetter neighbourWorld, BlockPos neighbourPos, BlockState neighbourState, Direction direction, Operation<Boolean> original, BlockState state, Direction preferredDirection, Direction ignore, BlockAndTintGetter world, BlockPos pos) {
 		boolean shouldConnect = original.call(neighbourWorld, neighbourPos, neighbourState, direction);
-
 		BlockEntity be = world.getBlockEntity(neighbourPos);
-
 		if (be instanceof ILockablePipe lockablePipe) {
 			if (lockablePipe.locked()) {
 				var oppositeProperty = FluidPipeBlock.PROPERTY_BY_DIRECTION.get(direction.getOpposite());
@@ -33,5 +33,13 @@ public class FluidPipeBlockMixin {
 		}
 
 		return shouldConnect;
+	}
+
+	@Inject(method = "updateBlockState", at = @At("HEAD"), cancellable = true)
+	private void updateBlockState(BlockState state, Direction preferredDirection, Direction ignore, BlockAndTintGetter world, BlockPos pos, CallbackInfoReturnable<BlockState> cir) {
+		if (world.getBlockEntity(pos) instanceof ILockablePipe lockablePipe)
+			if (lockablePipe.locked()) {
+				cir.setReturnValue(state);
+			}
 	}
 }

--- a/src/main/resources/tfmg.mixins.json
+++ b/src/main/resources/tfmg.mixins.json
@@ -11,6 +11,7 @@
     "GoggleOverlayRendererMixin",
     "MobEffectInstanceMixin",
     "PipeAttachmentModelMixin",
+    "FluidPipeBlockEntityMixin",
     "RecipeProviderMixin",
     "UtilMixin",
     "accessor.FluidTankBlockEntityAccessor",


### PR DESCRIPTION
This allows Screwdrivers to lock any instance of `FluidPipeBlockEntity` via the new `ILockablePipe` interface.

Notably, this allows screwdrivers to lock copper fluid pipes instead of just the custom TFMG variants.

closes #5 