### PR TITLE
Remove floats in vat goggle info and change vat types to ResourceLocation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ Please note that not all bugs are fixed and some new additions are subject to ch
 - Engine Cylinders and Turbine Blades have recipes again.
 - Engines of different types no longer connect.
 - Encased cogwheel item models now show the correct cogwheel type.
-- Steel, Aluminium & Heavy Casings can now encase blocks properly.
+- Steel, Aluminum & Heavy Casings can now encase blocks properly.
 - Fixed typos in some cogwheel texture names.
 
 ### Changes:
@@ -50,6 +50,11 @@ Please note that not all bugs are fixed and some new additions are subject to ch
 - Vat:
   - Vat Machines now display personal goggle/multimeter info if they are operational or not.
   - Vats can now be multi-placed.
+  - Vat pressure and heat level do not display floats anymore
+  - Vat recipe `allowed_vat_types` now use a list of `ResourceLocation`s
+  - Vat types now use `ResourceLocation` in replacement of `String`
+  - `VatRecipeGen` no longer uses generics
+  - Vat pressure is limited to between `-9` and `9` (inclusive)
 - Electricity:
   - Modified the extraction calculation on Cable Insulators to improve the amount of FE being consumed.
 - Engines & Engine Adjacent:
@@ -65,10 +70,10 @@ Please note that not all bugs are fixed and some new additions are subject to ch
   - Surface Scanners now update their detection if they have been moved (if they are on a Sub-Level)
   - Surface Scanners now produce a redstone signal based on the distance from a detected oil chunk.
 - Added TFMG Encased wooden cogwheels.
-- Added Industrial Aluminium encased blocks.
+- Added Industrial Aluminum encased blocks.
 - Cleaned up Neon Tube.
 - Marked "The Factory Must WORK" as incompatible with Community Edition due to conflicting bug fixes. This may be revoked at a later date.
-- Added credits to the mods.toml
+- Added credits to `neoforge.mods.toml`
 
 ### API Changes:
 - Added Sable Companion as an embedded api.
@@ -78,12 +83,12 @@ Please note that not all bugs are fixed and some new additions are subject to ch
 - Engine Upgrades now use the `tfmg:upgrades_on_side` engine tag for rendering.
 - Removed `RegularEngineBlockEntity.EngineType` enum.
 - Internal tag enums in `TFMGTags` have been renamed (`TFMGTags.TFMGItemTags` → `TFMGTags.Items`).
-- Added `formatFluid` in TFMGUtils for fluid units.
-- Added `fluidProduction` in TFMGTexts for fluid production.
+- Added `formatFluid` in `TFMGUtils` for fluid units.
+- Added `fluidProduction` in `TFMGTexts` for fluid production.
 - Renamed & remapped Heavy casing encased blocks to Heavy encased.
-- Added Decimal Formats to TFMGTexts for properly formatting numbers.
+- Added Decimal Formats to `TFMGTexts` for properly formatting numbers.
 - Re-introduced Micron unit just in case.
-- Added `returnItemToInventory` method in TFMGUtils. Currently only used in the Polarizer.
+- Added `returnItemToInventory` method in `TFMGUtils`. Currently only used in the Polarizer.
 
 ### New Translations:
 People who wish to translate this mod should look out for changes here.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,8 +51,8 @@ Please note that not all bugs are fixed and some new additions are subject to ch
   - Vat Machines now display personal goggle/multimeter info if they are operational or not.
   - Vats can now be multi-placed.
   - Vat pressure and heat level do not display floats anymore
-  - Vat recipe `allowed_vat_types` now use a list of `ResourceLocation`s
-  - Vat types now use `ResourceLocation` in replacement of `String`
+  - Vat recipe `allowed_vat_types` now uses a list of `ResourceLocation`s
+  - Vat types now use `ResourceLocation` in place of `String`
   - `VatRecipeGen` no longer uses generics
   - Vat pressure is limited to between `-9` and `9` (inclusive)
 - Electricity:

--- a/gradle.properties
+++ b/gradle.properties
@@ -31,5 +31,5 @@ mod_license=MIT
 mod_version=1.2.3a-community
 mod_group_id=com.drmangotea
 mod_authors= DrMangoTea, Pepa, Luna
-mod_credits= Anyone who has contributed on the Community Edition GitHub
+mod_credits= Anyone who has contributed on the Community Edition version on GitHub
 mod_description= Create: The Factory Must Grow brings the age of steel, oil and electricity to the Create mod

--- a/src/main/java/com/drmangotea/tfmg/content/machinery/vat/base/VatBlock.java
+++ b/src/main/java/com/drmangotea/tfmg/content/machinery/vat/base/VatBlock.java
@@ -1,5 +1,6 @@
 package com.drmangotea.tfmg.content.machinery.vat.base;
 
+import com.drmangotea.tfmg.TFMG;
 import com.drmangotea.tfmg.base.lang.TFMGLang;
 import com.drmangotea.tfmg.registry.TFMGBlockEntities;
 import com.simibubi.create.api.connectivity.ConnectivityHandler;
@@ -7,6 +8,7 @@ import com.simibubi.create.content.equipment.wrench.IWrenchable;
 import com.simibubi.create.foundation.block.IBE;
 
 import net.minecraft.core.BlockPos;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.sounds.SoundEvents;
 import net.minecraft.util.StringRepresentable;
 import net.minecraft.world.InteractionResult;
@@ -31,8 +33,7 @@ import net.minecraft.world.phys.shapes.VoxelShape;
 import net.neoforged.neoforge.common.util.DeferredSoundType;
 
 public class VatBlock extends Block implements IWrenchable, IBE<VatBlockEntity> {
-
-    public final String vatType;
+    public final ResourceLocation vatType;
 
     public static final BooleanProperty TOP = BooleanProperty.create("top");
     public static final BooleanProperty BOTTOM = BooleanProperty.create("bottom");
@@ -41,16 +42,16 @@ public class VatBlock extends Block implements IWrenchable, IBE<VatBlockEntity> 
 
 
     public static VatBlock steel(Properties properties){
-        return new VatBlock(properties,"tfmg:steel_vat");
+        return new VatBlock(properties, TFMG.asResource("steel_vat"));
     }
     public static VatBlock cast_iron(Properties properties){
-        return new VatBlock(properties,"tfmg:cast_iron_vat");
+        return new VatBlock(properties, TFMG.asResource("cast_iron_vat"));
     }
     public static VatBlock fireproof(Properties properties){
-        return new VatBlock(properties,"tfmg:firebrick_lined_vat");
+        return new VatBlock(properties, TFMG.asResource("firebrick_lined_vat"));
     }
 
-    public VatBlock(Properties properties, String vatType) {
+    public VatBlock(Properties properties, ResourceLocation vatType) {
         super(properties);
         registerDefaultState(defaultBlockState().setValue(TOP, true)
                 .setValue(BOTTOM, true)
@@ -121,9 +122,8 @@ public class VatBlock extends Block implements IWrenchable, IBE<VatBlockEntity> 
     public void onRemove(BlockState state, Level world, BlockPos pos, BlockState newState, boolean isMoving) {
         if (state.hasBlockEntity() && (state.getBlock() != newState.getBlock() || !newState.hasBlockEntity())) {
             BlockEntity be = world.getBlockEntity(pos);
-            if (!(be instanceof VatBlockEntity))
+            if (!(be instanceof VatBlockEntity tankBE))
                 return;
-            VatBlockEntity tankBE = (VatBlockEntity) be;
             world.removeBlockEntity(pos);
             ConnectivityHandler.splitMulti(tankBE);
         }
@@ -143,18 +143,13 @@ public class VatBlock extends Block implements IWrenchable, IBE<VatBlockEntity> 
         if (mirror == Mirror.NONE)
             return state;
         boolean x = mirror == Mirror.FRONT_BACK;
-        switch (state.getValue(SHAPE)) {
-            case WINDOW_NE:
-                return state.setValue(SHAPE, x ? Shape.WINDOW_NW : Shape.WINDOW_SE);
-            case WINDOW_NW:
-                return state.setValue(SHAPE, x ? Shape.WINDOW_NE : Shape.WINDOW_SW);
-            case WINDOW_SE:
-                return state.setValue(SHAPE, x ? Shape.WINDOW_SW : Shape.WINDOW_NE);
-            case WINDOW_SW:
-                return state.setValue(SHAPE, x ? Shape.WINDOW_SE : Shape.WINDOW_NW);
-            default:
-                return state;
-        }
+        return switch (state.getValue(SHAPE)) {
+            case WINDOW_NE -> state.setValue(SHAPE, x ? Shape.WINDOW_NW : Shape.WINDOW_SE);
+            case WINDOW_NW -> state.setValue(SHAPE, x ? Shape.WINDOW_NE : Shape.WINDOW_SW);
+            case WINDOW_SE -> state.setValue(SHAPE, x ? Shape.WINDOW_SW : Shape.WINDOW_NE);
+            case WINDOW_SW -> state.setValue(SHAPE, x ? Shape.WINDOW_SE : Shape.WINDOW_NW);
+            default -> state;
+        };
     }
 
     @Override
@@ -165,18 +160,13 @@ public class VatBlock extends Block implements IWrenchable, IBE<VatBlockEntity> 
     }
 
     private BlockState rotateOnce(BlockState state) {
-        switch (state.getValue(SHAPE)) {
-            case WINDOW_NE:
-                return state.setValue(SHAPE, Shape.WINDOW_SE);
-            case WINDOW_NW:
-                return state.setValue(SHAPE, Shape.WINDOW_NE);
-            case WINDOW_SE:
-                return state.setValue(SHAPE, Shape.WINDOW_SW);
-            case WINDOW_SW:
-                return state.setValue(SHAPE, Shape.WINDOW_NW);
-            default:
-                return state;
-        }
+        return switch (state.getValue(SHAPE)) {
+            case WINDOW_NE -> state.setValue(SHAPE, Shape.WINDOW_SE);
+            case WINDOW_NW -> state.setValue(SHAPE, Shape.WINDOW_NE);
+            case WINDOW_SE -> state.setValue(SHAPE, Shape.WINDOW_SW);
+            case WINDOW_SW -> state.setValue(SHAPE, Shape.WINDOW_NW);
+            default -> state;
+        };
     }
 
     public enum Shape implements StringRepresentable {

--- a/src/main/java/com/drmangotea/tfmg/content/machinery/vat/base/VatBlockEntity.java
+++ b/src/main/java/com/drmangotea/tfmg/content/machinery/vat/base/VatBlockEntity.java
@@ -1,5 +1,6 @@
 package com.drmangotea.tfmg.content.machinery.vat.base;
 
+import com.drmangotea.tfmg.TFMG;
 import com.drmangotea.tfmg.base.TFMGUtils;
 import com.drmangotea.tfmg.base.lang.TFMGTexts;
 import com.drmangotea.tfmg.content.machinery.vat.compressor.CompressorBlockEntity;
@@ -60,6 +61,7 @@ import net.neoforged.neoforge.fluids.crafting.SizedFluidIngredient;
 import net.neoforged.neoforge.items.IItemHandler;
 import net.neoforged.neoforge.items.IItemHandlerModifiable;
 import net.neoforged.neoforge.items.wrapper.CombinedInvWrapper;
+import org.jetbrains.annotations.NotNull;
 
 import javax.annotation.Nullable;
 import java.util.*;
@@ -77,7 +79,7 @@ public class VatBlockEntity extends SmartBlockEntity implements IHaveGoggleInfor
     //fluid inventory
     public SmartFluidTankBehaviour inputTank;
     public SmartFluidTankBehaviour outputTank;
-    private Couple<SmartFluidTankBehaviour> tanks;
+    private final Couple<SmartFluidTankBehaviour> tanks;
     //capabilities
     protected IFluidHandler fluidCapability;
     protected IItemHandlerModifiable itemCapability;
@@ -110,9 +112,6 @@ public class VatBlockEntity extends SmartBlockEntity implements IHaveGoggleInfor
     int pressure = 0;
     HeatCondition heatCondition = HeatCondition.NONE;
     private static final Object vatRecipeKey = new Object();
-    // display
-    private int minValue = 0;
-    private int maxValue = 0;
 
     public VatBlockEntity(BlockEntityType<?> type, BlockPos pos, BlockState state) {
         super(type, pos, state);
@@ -131,8 +130,6 @@ public class VatBlockEntity extends SmartBlockEntity implements IHaveGoggleInfor
         height = 1;
         width = 1;
         refreshCapability();
-
-
     }
 
     public Couple<SmartFluidTankBehaviour> getTanks() {
@@ -179,27 +176,23 @@ public class VatBlockEntity extends SmartBlockEntity implements IHaveGoggleInfor
 
     protected void updateConnectivity() {
         updateConnectivity = false;
-        if (level.isClientSide)
-            return;
-        if (!isController())
+        if (level == null || level.isClientSide || !isController())
             return;
         ConnectivityHandler.formMulti(this);
-
-
     }
 
     //goggle stuff
-    public MutableComponent getHeatComponent(boolean forGoggles, boolean useBlocksAsBars, ChatFormatting... styles) {
-        return componentHelper("heat", 10 + heatLevel, forGoggles, useBlocksAsBars, styles);
+    public MutableComponent getHeatComponent(boolean forGoggles) {
+        return componentHelper("heat", heatLevel, forGoggles);
     }
 
-    public MutableComponent getPressureComponent(boolean forGoggles, boolean useBlocksAsBars, ChatFormatting... styles) {
-        return componentHelper("pressure", 10 + pressure, forGoggles, useBlocksAsBars, styles);
+    public MutableComponent getPressureComponent(boolean forGoggles) {
+        return componentHelper("pressure", pressure, forGoggles);
     }
 
-    private MutableComponent componentHelper(String label, int level, boolean forGoggles, boolean useBlocksAsBars,
+    private MutableComponent componentHelper(String label, int level, boolean forGoggles,
                                              ChatFormatting... styles) {
-        MutableComponent base = useBlocksAsBars ? blockComponent(level) : barComponent(level);
+        MutableComponent base = barComponent(level);
 
         if (!forGoggles)
             return base;
@@ -212,80 +205,40 @@ public class VatBlockEntity extends SmartBlockEntity implements IHaveGoggleInfor
                 .append(CreateLang.translateDirect("vat." + label + "_dots")
                         .withStyle(style2))
                 .append(base)
-                .append("(" + level / 10f + ")");
-    }
-
-    private MutableComponent blockComponent(int level) {
-        return Component.literal("" + "\u2588".repeat(minValue) + "\u2592".repeat(level - minValue) + "\u2591".repeat(maxValue - level));
+                .append("(" + level + ")");
     }
 
     private MutableComponent barComponent(int level) {
-        ChatFormatting color = level - minValue > 19 ? ChatFormatting.DARK_RED : ChatFormatting.DARK_GREEN;
-        switch (level - minValue) {
-            case 1:
-                color = ChatFormatting.BLUE;
-                break;
-            case 2:
-                color = ChatFormatting.DARK_AQUA;
-                break;
-            case 3:
-                color = ChatFormatting.DARK_AQUA;
-                break;
-            case 4:
-                color = ChatFormatting.AQUA;
-                break;
-            case 5:
-                color = ChatFormatting.AQUA;
-                break;
-            case 6:
-                color = ChatFormatting.AQUA;
-                break;
-            case 7:
-                color = ChatFormatting.AQUA;
-                break;
-            case 8:
-                color = ChatFormatting.AQUA;
-                break;
-            case 11:
-                color = ChatFormatting.YELLOW;
-                break;
-            case 12:
-                color = ChatFormatting.YELLOW;
-                break;
-            case 13:
-                color = ChatFormatting.YELLOW;
-                break;
-            case 14:
-                color = ChatFormatting.YELLOW;
-                break;
-            case 15:
-                color = ChatFormatting.YELLOW;
-                break;
-            case 16:
-                color = ChatFormatting.GOLD;
-                break;
-            case 17:
-                color = ChatFormatting.RED;
-                break;
-            case 18:
-                color = ChatFormatting.RED;
-                break;
-            case 19:
-                color = ChatFormatting.DARK_RED;
-                break;
-
-        }
+        // display
+        int minValue = 0;
+        ChatFormatting color = getColor(level, minValue);
 
 
+        int maxValue = 0;
         return Component.empty()
-                .append(bars(Math.max(0, minValue - 1), ChatFormatting.RED))
-                .append(bars(minValue > 0 ? 1 : 0, ChatFormatting.GOLD))
+                .append(bars(0, ChatFormatting.RED))
+                .append(bars(0, ChatFormatting.GOLD))
                 .append(bars(Math.max(0, level - minValue), color))
                 .append(bars(Math.max(0, maxValue - level), ChatFormatting.BLUE))
-                .append(bars(Math.max(0, Math.min(18 - maxValue, ((maxValue / 5 + 1) * 5) - maxValue)),
+                .append(bars(Math.min(18 - maxValue, 5 - maxValue),
                         ChatFormatting.DARK_GRAY));
 
 
+    }
+
+    private static @NotNull ChatFormatting getColor(int level, int minValue) {
+        ChatFormatting color = level - minValue > 19 ? ChatFormatting.DARK_RED : ChatFormatting.DARK_GREEN;
+        color = switch (level - minValue) {
+            case 1 -> ChatFormatting.BLUE;
+            case 2, 3 -> ChatFormatting.DARK_AQUA;
+            case 4, 5, 6, 8, 7 -> ChatFormatting.AQUA;
+            case 11, 12, 13, 14, 15 -> ChatFormatting.YELLOW;
+            case 16 -> ChatFormatting.GOLD;
+            case 17, 18 -> ChatFormatting.RED;
+            case 19 -> ChatFormatting.DARK_RED;
+            default -> color;
+        };
+        return color;
     }
 
     private MutableComponent bars(int level, ChatFormatting format) {
@@ -539,7 +492,7 @@ public class VatBlockEntity extends SmartBlockEntity implements IHaveGoggleInfor
 
         if (lastKnownPos == null)
             lastKnownPos = getBlockPos();
-        else if (!lastKnownPos.equals(worldPosition) && worldPosition != null) {
+        else if (!lastKnownPos.equals(worldPosition)) {
             onPositionChanged();
             return;
         }
@@ -897,7 +850,7 @@ public class VatBlockEntity extends SmartBlockEntity implements IHaveGoggleInfor
         if (be == null)
             return;
 
-        if (((VatBlock) getBlockState().getBlock()).vatType == "tfmg:firebrick_lined_vat")
+        if (Objects.equals(((VatBlock) getBlockState().getBlock()).vatType, TFMG.asResource("firebrick_lined_vat")))
             return;
 
         be.setWindows(!be.window);
@@ -931,19 +884,7 @@ public class VatBlockEntity extends SmartBlockEntity implements IHaveGoggleInfor
                     if (!VatBlock.isVat(blockState))
                         continue;
 
-                    VatBlock.Shape shape = VatBlock.Shape.PLAIN;
-                    if (window) {
-                        // SIZE 1: Every tank has a window
-                        if (width == 1)
-                            shape = VatBlock.Shape.WINDOW;
-                        // SIZE 2: Every tank has a corner window
-                        if (width == 2)
-                            shape = xOffset == 0 ? zOffset == 0 ? VatBlock.Shape.WINDOW_NW : VatBlock.Shape.WINDOW_SW
-                                    : zOffset == 0 ? VatBlock.Shape.WINDOW_NE : VatBlock.Shape.WINDOW_SE;
-                        // SIZE 3: Tanks in the center have a window
-                        if (width == 3 && abs(abs(xOffset) - abs(zOffset)) == 1)
-                            shape = VatBlock.Shape.WINDOW;
-                    }
+                    VatBlock.Shape shape = getShape(window, xOffset, zOffset);
 
                     level.setBlock(pos, blockState.setValue(VatBlock.SHAPE, shape), 22);
                     level.getChunkSource()
@@ -952,6 +893,23 @@ public class VatBlockEntity extends SmartBlockEntity implements IHaveGoggleInfor
                 }
             }
         }
+    }
+
+    private VatBlock.@NotNull Shape getShape(boolean window, int xOffset, int zOffset) {
+        VatBlock.Shape shape = VatBlock.Shape.PLAIN;
+        if (window) {
+            // SIZE 1: Every tank has a window
+            if (width == 1)
+                shape = VatBlock.Shape.WINDOW;
+            // SIZE 2: Every tank has a corner window
+            if (width == 2)
+                shape = xOffset == 0 ? zOffset == 0 ? VatBlock.Shape.WINDOW_NW : VatBlock.Shape.WINDOW_SW
+                        : zOffset == 0 ? VatBlock.Shape.WINDOW_NE : VatBlock.Shape.WINDOW_SE;
+            // SIZE 3: Tanks in the center have a window
+            if (width == 3 && abs(abs(xOffset) - abs(zOffset)) == 1)
+                shape = VatBlock.Shape.WINDOW;
+        }
+        return shape;
     }
 
     public void updateState() {
@@ -1052,8 +1010,8 @@ public class VatBlockEntity extends SmartBlockEntity implements IHaveGoggleInfor
         TFMGTexts.header("vat").style(ChatFormatting.GRAY)
                 .forGoggles(tooltip);
 
-        CreateLang.builder().add(getPressureComponent(true, false)).forGoggles(tooltip, 1);
-        CreateLang.builder().add(getHeatComponent(true, false)).forGoggles(tooltip, 1);
+        CreateLang.builder().add(getPressureComponent(true)).forGoggles(tooltip, 1);
+        CreateLang.builder().add(getHeatComponent(true)).forGoggles(tooltip, 1);
 
         TFMGTexts.Vat.attachments()
                 .style(ChatFormatting.GRAY)

--- a/src/main/java/com/drmangotea/tfmg/datagen/recipes/builder/VatRecipeGen.java
+++ b/src/main/java/com/drmangotea/tfmg/datagen/recipes/builder/VatRecipeGen.java
@@ -4,23 +4,16 @@ import com.drmangotea.tfmg.recipes.VatMachineRecipe;
 import com.drmangotea.tfmg.recipes.VatRecipeParams;
 import com.drmangotea.tfmg.registry.TFMGRecipeTypes;
 import com.simibubi.create.api.data.recipe.ProcessingRecipeGen;
-import com.simibubi.create.content.processing.recipe.ProcessingRecipe;
-import com.simibubi.create.content.processing.recipe.ProcessingRecipeBuilder;
-import com.simibubi.create.content.processing.recipe.ProcessingRecipeParams;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.data.PackOutput;
 import net.minecraft.resources.ResourceLocation;
 
 import java.util.concurrent.CompletableFuture;
 
-public abstract class VatRecipeGen<P extends ProcessingRecipeParams, R extends ProcessingRecipe<?, P>, B extends ProcessingRecipeBuilder<P, R, B>> extends ProcessingRecipeGen<VatRecipeParams, VatMachineRecipe, VatMachineRecipe.Builder<VatMachineRecipe>> {
-
-
+public abstract class VatRecipeGen extends ProcessingRecipeGen<VatRecipeParams, VatMachineRecipe, VatMachineRecipe.Builder<VatMachineRecipe>> {
 	public VatRecipeGen(PackOutput output, CompletableFuture<HolderLookup.Provider> registries, String namespace) {
 		super(output, registries, namespace);
 	}
-
-
 
 	@Override
 	protected TFMGRecipeTypes getRecipeType() {

--- a/src/main/java/com/drmangotea/tfmg/datagen/recipes/values/tfmg/TFMGVatRecipeGen.java
+++ b/src/main/java/com/drmangotea/tfmg/datagen/recipes/values/tfmg/TFMGVatRecipeGen.java
@@ -3,12 +3,12 @@ package com.drmangotea.tfmg.datagen.recipes.values.tfmg;
 
 import com.drmangotea.tfmg.TFMG;
 import com.drmangotea.tfmg.datagen.recipes.builder.VatRecipeGen;
-import com.drmangotea.tfmg.recipes.VatMachineRecipe;
 import com.drmangotea.tfmg.registry.TFMGFluids;
 import com.drmangotea.tfmg.registry.TFMGItems;
 import com.drmangotea.tfmg.registry.TFMGTags;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.data.PackOutput;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.material.Fluids;
 import net.neoforged.neoforge.fluids.crafting.SizedFluidIngredient;
@@ -27,7 +27,7 @@ public class TFMGVatRecipeGen extends VatRecipeGen {
 
 
     GeneratedRecipe
-            CONCRETE = create("concrete", b -> ((VatMachineRecipe.Builder<VatMachineRecipe>) b)
+            CONCRETE = create("concrete", b -> b
             .require(Blocks.SAND.asItem())
             .require(Blocks.GRAVEL.asItem())
             .require(TFMGItems.LIMESAND)
@@ -35,7 +35,7 @@ public class TFMGVatRecipeGen extends VatRecipeGen {
             .output(TFMGFluids.LIQUID_CONCRETE.get(), 32000)
             .values(mixing(true))
     ),
-            ARC_FURNACE_STEEL = create("arc_furnace_steel", b -> ((VatMachineRecipe.Builder<VatMachineRecipe>) b)
+            ARC_FURNACE_STEEL = create("arc_furnace_steel", b -> b
                     .require(crushedRawIron())
                     .require(TFMGTags.Items.FLUX.tag)
                     .require(TFMGItems.COAL_COKE_DUST)
@@ -44,12 +44,12 @@ public class TFMGVatRecipeGen extends VatRecipeGen {
                     .output(TFMGFluids.MOLTEN_SLAG.get(), 288)
                     .duration(20)
                     .values(arcBlasting())),
-            NEON = create("neon", b -> ((VatMachineRecipe.Builder<VatMachineRecipe>) b)
+            NEON = create("neon", b -> b
                     .require(TFMGFluids.AIR.get(), 1000)
                     .output(TFMGFluids.NEON.get(), 1)
                     .duration(10)
                     .values(centrifuge())),
-            SULFURIC_ACID = create("sulfuric_acid", b -> ((VatMachineRecipe.Builder<VatMachineRecipe>) b)
+            SULFURIC_ACID = create("sulfuric_acid", b -> b
                     .require(SizedFluidIngredient.of(water(), 1000))
                     .require(sulfurDust())
                     .require(sulfurDust())
@@ -58,34 +58,34 @@ public class TFMGVatRecipeGen extends VatRecipeGen {
                     .output(sulfuricAcid(), 500)
                     .values(mixing(true))),
 
-    RUBBER = create("rubber", b -> ((VatMachineRecipe.Builder<VatMachineRecipe>) b)
+    RUBBER = create("rubber", b -> b
             .require(SizedFluidIngredient.of(heavyOil(), 250))
             .require(sulfurDust())
             .output(rubber())
             .values(heatedmixing(true))),
 
-    NAPHTHA = create("naphtha", b -> ((VatMachineRecipe.Builder<VatMachineRecipe>) b)
+    NAPHTHA = create("naphtha", b -> b
             .require(SizedFluidIngredient.of(naphtha(), 500))
             .output(ethylene(), 250)
             .output(propylene(), 250)
             .values(heatedmixing(true))),
 
-    PLASTIC_FROM_ETHYLENE = create("plastic_from_ethylene", b -> ((VatMachineRecipe.Builder<VatMachineRecipe>) b)
+    PLASTIC_FROM_ETHYLENE = create("plastic_from_ethylene", b -> b
             .require(SizedFluidIngredient.of(ethylene(), 500))
             .output(liquidPlastic(), 500)
             .values(heatedmixing(true))),
 
-            PLASTIC_FROM_PROPYLENE = create("plastic_from_propylene", b -> ((VatMachineRecipe.Builder<VatMachineRecipe>) b)
+            PLASTIC_FROM_PROPYLENE = create("plastic_from_propylene", b -> b
                     .require(SizedFluidIngredient.of(propylene(), 500))
                     .output(liquidPlastic(), 500)
                     .values(heatedmixing(true))),
-            ETCHED_CIRCUIT_BOARD = create("etched_circuit_board", b -> ((VatMachineRecipe.Builder<VatMachineRecipe>) b)
+            ETCHED_CIRCUIT_BOARD = create("etched_circuit_board", b -> b
                     .require(TFMGItems.COATED_CIRCUIT_BOARD)
                     .require(TFMGFluids.SULFURIC_ACID.getSource(), 250)
                     .output(TFMGItems.ETCHED_CIRCUIT_BOARD)
                     .duration(100)
                     .values(noMachines())),
-            ALUMINUM = create("aluminum", b -> ((VatMachineRecipe.Builder<VatMachineRecipe>) b)
+            ALUMINUM = create("aluminum", b -> b
                     .require(TFMGItems.BAUXITE_POWDER)
                     .require(TFMGItems.BAUXITE_POWDER)
                     .require(TFMGItems.BAUXITE_POWDER)
@@ -124,8 +124,8 @@ public class TFMGVatRecipeGen extends VatRecipeGen {
         params.machines.add("tfmg:electrode");
         params.machines.add("tfmg:electrode");
         params.allowedVatTypes = new ArrayList<>();
-        params.allowedVatTypes.add("tfmg:steel_vat");
-        params.allowedVatTypes.add("tfmg:firebrick_lined_vat");
+        params.allowedVatTypes.add(TFMG.asResource("steel_vat"));
+        params.allowedVatTypes.add(TFMG.asResource("firebrick_lined_vat"));
         params.heat = 2;
         return params;
     }
@@ -139,9 +139,9 @@ public class TFMGVatRecipeGen extends VatRecipeGen {
         params.machines.add("tfmg:mixing");
         params.allowedVatTypes = new ArrayList<>();
         if (allowsCastIronVat)
-            params.allowedVatTypes.add("tfmg:cast_iron_vat");
-        params.allowedVatTypes.add("tfmg:steel_vat");
-        params.allowedVatTypes.add("tfmg:firebrick_lined_vat");
+            params.allowedVatTypes.add(TFMG.asResource("cast_iron_vat"));
+        params.allowedVatTypes.add(TFMG.asResource("steel_vat"));
+        params.allowedVatTypes.add(TFMG.asResource("firebrick_lined_vat"));
         return params;
     }
 
@@ -150,9 +150,9 @@ public class TFMGVatRecipeGen extends VatRecipeGen {
         params.machines.add("tfmg:mixing");
         params.allowedVatTypes = new ArrayList<>();
         if (allowsCastIronVat)
-            params.allowedVatTypes.add("tfmg:cast_iron_vat");
-        params.allowedVatTypes.add("tfmg:steel_vat");
-        params.allowedVatTypes.add("tfmg:firebrick_lined_vat");
+            params.allowedVatTypes.add(TFMG.asResource("cast_iron_vat"));
+        params.allowedVatTypes.add(TFMG.asResource("steel_vat"));
+        params.allowedVatTypes.add(TFMG.asResource("firebrick_lined_vat"));
         params.heat = 2;
         return params;
     }
@@ -166,9 +166,9 @@ public class TFMGVatRecipeGen extends VatRecipeGen {
     public VatRecipeValues noMachines() {
         VatRecipeValues params = new VatRecipeValues();
         params.allowedVatTypes = new ArrayList<>();
-        params.allowedVatTypes.add("tfmg:steel_vat");
-        params.allowedVatTypes.add("tfmg:cast_iron_vat");
-        params.allowedVatTypes.add("tfmg:firebrick_lined_vat");
+        params.allowedVatTypes.add(TFMG.asResource("steel_vat"));
+        params.allowedVatTypes.add(TFMG.asResource("cast_iron_vat"));
+        params.allowedVatTypes.add(TFMG.asResource("firebrick_lined_vat"));
         params.minSize = 1;
         return params;
     }
@@ -177,9 +177,9 @@ public class TFMGVatRecipeGen extends VatRecipeGen {
         VatRecipeValues params = new VatRecipeValues();
 
         params.allowedVatTypes = new ArrayList<>();
-        params.allowedVatTypes.add("tfmg:cast_iron_vat");
-        params.allowedVatTypes.add("tfmg:steel_vat");
-        params.allowedVatTypes.add("tfmg:firebrick_lined_vat");
+        params.allowedVatTypes.add(TFMG.asResource("cast_iron_vat"));
+        params.allowedVatTypes.add(TFMG.asResource("steel_vat"));
+        params.allowedVatTypes.add(TFMG.asResource("firebrick_lined_vat"));
         params.heat = 5;
         return params;
     }
@@ -199,7 +199,7 @@ public class TFMGVatRecipeGen extends VatRecipeGen {
         params.machines.add("tfmg:graphite_electrode");
         params.minSize = 9;
         params.allowedVatTypes = new ArrayList<>();
-        params.allowedVatTypes.add("tfmg:firebrick_lined_vat");
+        params.allowedVatTypes.add(TFMG.asResource("firebrick_lined_vat"));
         return params;
     }
 
@@ -209,7 +209,7 @@ public class TFMGVatRecipeGen extends VatRecipeGen {
         public int minSize;
         public int heat;
         public int pressure;
-        public List<String> allowedVatTypes;
+        public List<ResourceLocation> allowedVatTypes;
 
 
         public VatRecipeValues() {
@@ -218,9 +218,9 @@ public class TFMGVatRecipeGen extends VatRecipeGen {
             heat = 0;
             pressure = 0;
             allowedVatTypes = new ArrayList<>();
-            allowedVatTypes.add("tfmg:steel_vat");
-            allowedVatTypes.add("tfmg:cast_iron_vat");
-            allowedVatTypes.add("tfmg:firebrick_lined_vat");
+            allowedVatTypes.add(TFMG.asResource("steel_vat"));
+            allowedVatTypes.add(TFMG.asResource("cast_iron_vat"));
+            allowedVatTypes.add(TFMG.asResource("firebrick_lined_vat"));
 
         }
 

--- a/src/main/java/com/drmangotea/tfmg/integration/jei/category/ChemicalVatCategory.java
+++ b/src/main/java/com/drmangotea/tfmg/integration/jei/category/ChemicalVatCategory.java
@@ -1,5 +1,6 @@
 package com.drmangotea.tfmg.integration.jei.category;
 
+import com.drmangotea.tfmg.TFMG;
 import com.drmangotea.tfmg.base.lang.TFMGLang;
 import com.drmangotea.tfmg.recipes.VatMachineRecipe;
 import com.drmangotea.tfmg.registry.TFMGGuiTextures;
@@ -15,6 +16,7 @@ import net.createmod.ponder.api.PonderPalette;
 import net.minecraft.ChatFormatting;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.network.chat.Component;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.Ingredient;
 import org.apache.commons.lang3.mutable.MutableInt;
@@ -89,7 +91,7 @@ public class ChemicalVatCategory extends CreateRecipeCategory<VatMachineRecipe> 
 
     public void draw(VatMachineRecipe recipe, IRecipeSlotsView iRecipeSlotsView, GuiGraphics graphics, double mouseX, double mouseY) {
         List<String> machines = recipe.machines;
-        List<String> allowedVatTypes = recipe.allowedVatTypes;
+        List<ResourceLocation> allowedVatTypes = recipe.allowedVatTypes;
         TFMGGuiTextures.VAT.render(graphics, 0, 24);
         drawVatTypes(allowedVatTypes, graphics);
         drawSprites(machines, graphics);
@@ -117,12 +119,6 @@ public class ChemicalVatCategory extends CreateRecipeCategory<VatMachineRecipe> 
     @NotNull
     public List<Component> getTooltipStrings(VatMachineRecipe recipe, IRecipeSlotsView recipeSlotsView, double mouseX, double mouseY) {
         List<Component> tooltip = new ArrayList<>();
-        int xOffset = -7;
-        int minX = 150 + xOffset;
-        int maxX = minX + 18;
-        int minY = 90;
-        int maxY = minY + 18;
-
         int pressure = recipe.pressure;
 
         if (mouseY > -3 && mouseY < 43 && mouseX > 127 && mouseX < 170) {
@@ -222,11 +218,11 @@ public class ChemicalVatCategory extends CreateRecipeCategory<VatMachineRecipe> 
         }
     }
 
-    private void drawVatTypes(List<String> allowedVatTypes, GuiGraphics graphics) {
-        if (allowedVatTypes.contains("tfmg:firebrick_lined_vat") && allowedVatTypes.size() == 1) {
+    private void drawVatTypes(List<ResourceLocation> allowedVatTypes, GuiGraphics graphics) {
+        if (allowedVatTypes.contains(TFMG.asResource("firebrick_lined_vat")) && allowedVatTypes.size() == 1) {
             TFMGGuiTextures.FIREPROOF_BRICK_OVERLAY.render(graphics, 55 - 48, 32);
         }
-        if (allowedVatTypes.contains("tfmg:cast_iron_vat") && allowedVatTypes.size() == 1) {
+        if (allowedVatTypes.contains(TFMG.asResource("cast_iron_vat")) && allowedVatTypes.size() == 1) {
             TFMGGuiTextures.CAST_IRON_VAT_OVERLAY.render(graphics, 0, 24);
         }
     }

--- a/src/main/java/com/drmangotea/tfmg/recipes/VatMachineRecipe.java
+++ b/src/main/java/com/drmangotea/tfmg/recipes/VatMachineRecipe.java
@@ -18,7 +18,7 @@ import java.util.List;
 public class VatMachineRecipe extends ProcessingRecipe<RecipeInput, VatRecipeParams> {
 
     public List<String> machines;
-    public List<String> allowedVatTypes;
+    public List<ResourceLocation> allowedVatTypes;
     public int minSize;
     public int heatLevel= 0;
 

--- a/src/main/java/com/drmangotea/tfmg/recipes/VatRecipeParams.java
+++ b/src/main/java/com/drmangotea/tfmg/recipes/VatRecipeParams.java
@@ -1,5 +1,6 @@
 package com.drmangotea.tfmg.recipes;
 
+import com.drmangotea.tfmg.TFMG;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.MapCodec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
@@ -8,6 +9,7 @@ import net.createmod.catnip.codecs.stream.CatnipStreamCodecBuilders;
 import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.network.codec.ByteBufCodecs;
 import net.minecraft.network.codec.StreamCodec;
+import net.minecraft.resources.ResourceLocation;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -15,24 +17,24 @@ import java.util.function.Function;
 
 public class VatRecipeParams extends ProcessingRecipeParams {
 
-    public static List<String> types = new ArrayList<>();
+    public static List<ResourceLocation> types = new ArrayList<>();
 
     static {
-        types.add("tfmg:steel_vat");
-        types.add("tfmg:cast_iron_vat");
-        types.add("tfmg:firebrick_lined_vat");
+        types.add(TFMG.asResource("steel_vat"));
+        types.add(TFMG.asResource("tcast_iron_vat"));
+        types.add(TFMG.asResource("firebrick_lined_vat"));
     }
 
     public static MapCodec<VatRecipeParams> CODEC = RecordCodecBuilder.mapCodec(instance -> instance.group(
             codec(VatRecipeParams::new).forGetter(Function.identity()),
-            Codec.INT.optionalFieldOf("min_size", 0)
+            Codec.intRange(0, Integer.MAX_VALUE).optionalFieldOf("min_size", 0)
                     .forGetter(VatRecipeParams::getMinSize),
             Codec.INT.optionalFieldOf("heat_level", 0)
                     .forGetter(VatRecipeParams::getHeatLevel),
-            Codec.INT.optionalFieldOf("pressure", 0)
+            Codec.intRange(-9, 9).optionalFieldOf("pressure", 0)
                     .forGetter(VatRecipeParams::getPressure),
             Codec.STRING.listOf().optionalFieldOf("machines", new ArrayList<>()).forGetter(VatRecipeParams::getMachines),
-            Codec.STRING.listOf().optionalFieldOf("allowed_vat_types", types).forGetter(VatRecipeParams::getAllowedVatTypes)
+            ResourceLocation.CODEC.listOf().optionalFieldOf("allowed_vat_types", types).forGetter(VatRecipeParams::getAllowedVatTypes)
     ).apply(instance, (params, min_size, heat_level,pressure, machines, allowed_vat_types) -> {
         params.machines = machines;
         params.min_size = min_size;
@@ -50,7 +52,7 @@ public class VatRecipeParams extends ProcessingRecipeParams {
     public int pressure;
 
     public List<String> machines;
-    public List<String> allowedVatTypes;
+    public List<ResourceLocation> allowedVatTypes;
 
     protected final int getHeatLevel() {
         return heat_level;
@@ -69,7 +71,7 @@ public class VatRecipeParams extends ProcessingRecipeParams {
         return machines;
     }
 
-    protected final List<String> getAllowedVatTypes() {
+    protected final List<ResourceLocation> getAllowedVatTypes() {
         return allowedVatTypes;
     }
 
@@ -82,7 +84,7 @@ public class VatRecipeParams extends ProcessingRecipeParams {
 
 
         CatnipStreamCodecBuilders.list(ByteBufCodecs.STRING_UTF8).encode(buffer, machines);
-        CatnipStreamCodecBuilders.list(ByteBufCodecs.STRING_UTF8).encode(buffer, allowedVatTypes);
+        CatnipStreamCodecBuilders.list(ResourceLocation.STREAM_CODEC).encode(buffer, allowedVatTypes);
 
     }
 
@@ -94,7 +96,6 @@ public class VatRecipeParams extends ProcessingRecipeParams {
         pressure = ByteBufCodecs.INT.decode(buffer);
 
         machines = CatnipStreamCodecBuilders.list(ByteBufCodecs.STRING_UTF8).decode(buffer);
-        allowedVatTypes = CatnipStreamCodecBuilders.list(ByteBufCodecs.STRING_UTF8).decode(buffer);
-
+        allowedVatTypes = CatnipStreamCodecBuilders.list(ResourceLocation.STREAM_CODEC).decode(buffer);
     }
 }

--- a/src/main/templates/META-INF/neoforge.mods.toml
+++ b/src/main/templates/META-INF/neoforge.mods.toml
@@ -38,6 +38,6 @@ file="META-INF/accesstransformer.cfg"
 [[dependencies."${mod_id}"]]
     modId = "tfmgtweaks"
     type = "incompatible"
-    reason = "Please remove TFMW as it adds mixins to fix bugs that we have already fixed ourselves."
+    reason = "TFMW adds mixins to fix bugs that we have already fixed ourselves."
     ordering="AFTER"
     side = "BOTH"


### PR DESCRIPTION
What this PR changes:
  - Vat pressure and heat level do not display floats anymore
  - Vat recipe `allowed_vat_types` now uses a list of `ResourceLocation`s
  - Vat types now use `ResourceLocation` in place of `String`
  - `VatRecipeGen` no longer uses generics
  - Vat pressure is limited to between `-9` and `9` (inclusive)
  

Vat types being a `ResourceLocation` change reason:
- It's easier to maintain
- Future PR I have planned