### PR TITLE
Surface scanner improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,7 +76,7 @@ Please note that not all bugs are fixed and some new additions are subject to ch
   - Compressors now notify the vat when their speed changes.
 - Electricity:
   - Modified the extraction calculation on Cable Insulators to improve the amount of FE being consumed.
-  - Nicer Cable Connector visuals.
+  - Nicer Cable visuals.
 - Engines & Engine Adjacent:
   - Improved Air Intake goggle tooltip.
   - Engine types are now a registry.
@@ -86,6 +86,8 @@ Please note that not all bugs are fixed and some new additions are subject to ch
     - Both cases require the input to have the `tfmg:engine_cylinder` component to be valid.
   - Engine types are safely remapped from their legacy values when reading from engine nbt.
   - Added JEI search aliases for Turbine Blades (`turbine`) & Engine Cylinders (`piston`).
+- Surface Scanners:
+    - Surface Scanners now update their detection if they have been moved (if they are on a Sub-Level).
 - Added TFMG Encased wooden cogwheels.
 - Added Industrial Aluminium encased blocks.
 - Cleaned up Neon Tube.
@@ -108,13 +110,14 @@ Please note that not all bugs are fixed and some new additions are subject to ch
 - Renamed & remapped `heavy_casing_encased_` blocks to `heavy_encased_`.
 - Added Decimal Formats to `TFMGTexts` for properly formatting numbers.
 - Re-introduced Micron unit just in case.
-- Added `returnItemToInventory` method in `TFMGUtils`.
+- Added `returnItemToInventory` method to `TFMGUtils`.
 - Removed `IndustrialMixerBlockEntity.MixerMode` enum.
 - Removed `TFMGLang.temporaryText`.
 - Removed `IHaveCables`.
 - Flamethrower Fuels now use the `tfmg:hellfire` tag instead of the `hellfire` boolean.
 - Flamethrower Fuels now use the `tfmg:cold` tag instead of the `is_cold` boolean.
 - Removed `"hellfire"` and `"is_cold"` from `FlamethrowerFuelType` in favour of tags.
+- Added `rotateQuat` method to `TFMGUtils`.
 - The following are deprecated for removal. If you are migrating your addon to depend on Community Edition I'd recommend fixing these:
   - `IElectric.getPos()` (returns long). We are trying to move away from storing BlockPos as a long and you should use `IElectric.position()` instead.
   - `Electrode.Properties.item(ItemEntry<?>)`. Electrodes are stored as a data component and this is now irrelevant. You should assign a default component to your electrode item instead.
@@ -140,5 +143,4 @@ People who wish to translate this mod should look out for changes here.
 ### Unmentioned:
 These don't go into the changelog yet.
 - Surface Scanners:
-  - Surface Scanners now update their detection if they have been moved (if they are on a Sub-Level)
   - Surface Scanners now produce a redstone signal based on the distance from a detected oil chunk.

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/gradlew
+++ b/gradlew
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 ##############################################################################
 #
@@ -84,7 +86,7 @@ done
 # shellcheck disable=SC2034
 APP_BASE_NAME=${0##*/}
 # Discard cd standard output in case $CDPATH is set (https://github.com/gradle/gradle/issues/25036)
-APP_HOME=$( cd "${APP_HOME:-./}" > /dev/null && pwd -P ) || exit
+APP_HOME=$( cd -P "${APP_HOME:-./}" > /dev/null && printf '%s\n' "$PWD" ) || exit
 
 # Use the maximum available, or set MAX_FD != -1 to use that value.
 MAX_FD=maximum
@@ -112,7 +114,7 @@ case "$( uname )" in                #(
   NONSTOP* )        nonstop=true ;;
 esac
 
-CLASSPATH=$APP_HOME/gradle/wrapper/gradle-wrapper.jar
+CLASSPATH="\\\"\\\""
 
 
 # Determine the Java command to use to start the JVM.
@@ -203,7 +205,7 @@ fi
 DEFAULT_JVM_OPTS='"-Xmx64m" "-Xms64m"'
 
 # Collect all arguments for the java command:
-#   * DEFAULT_JVM_OPTS, JAVA_OPTS, JAVA_OPTS, and optsEnvironmentVar are not allowed to contain shell fragments,
+#   * DEFAULT_JVM_OPTS, JAVA_OPTS, and optsEnvironmentVar are not allowed to contain shell fragments,
 #     and any embedded shellness will be escaped.
 #   * For example: A user cannot expect ${Hostname} to be expanded, as it is an environment variable and will be
 #     treated as '${Hostname}' itself on the command line.
@@ -211,7 +213,7 @@ DEFAULT_JVM_OPTS='"-Xmx64m" "-Xms64m"'
 set -- \
         "-Dorg.gradle.appname=$APP_BASE_NAME" \
         -classpath "$CLASSPATH" \
-        org.gradle.wrapper.GradleWrapperMain \
+        -jar "$APP_HOME/gradle/wrapper/gradle-wrapper.jar" \
         "$@"
 
 # Stop when "xargs" is not available.

--- a/gradlew.bat
+++ b/gradlew.bat
@@ -13,6 +13,8 @@
 @rem See the License for the specific language governing permissions and
 @rem limitations under the License.
 @rem
+@rem SPDX-License-Identifier: Apache-2.0
+@rem
 
 @if "%DEBUG%"=="" @echo off
 @rem ##########################################################################
@@ -68,11 +70,11 @@ goto fail
 :execute
 @rem Setup the command line
 
-set CLASSPATH=%APP_HOME%\gradle\wrapper\gradle-wrapper.jar
+set CLASSPATH=
 
 
 @rem Execute Gradle
-"%JAVA_EXE%" %DEFAULT_JVM_OPTS% %JAVA_OPTS% %GRADLE_OPTS% "-Dorg.gradle.appname=%APP_BASE_NAME%" -classpath "%CLASSPATH%" org.gradle.wrapper.GradleWrapperMain %*
+"%JAVA_EXE%" %DEFAULT_JVM_OPTS% %JAVA_OPTS% %GRADLE_OPTS% "-Dorg.gradle.appname=%APP_BASE_NAME%" -classpath "%CLASSPATH%" -jar "%APP_HOME%\gradle\wrapper\gradle-wrapper.jar" %*
 
 :end
 @rem End local scope for the variables with windows NT shell

--- a/src/main/java/com/drmangotea/tfmg/base/TFMGUtils.java
+++ b/src/main/java/com/drmangotea/tfmg/base/TFMGUtils.java
@@ -1,6 +1,5 @@
 package com.drmangotea.tfmg.base;
 
-
 import com.drmangotea.tfmg.TFMG;
 import com.drmangotea.tfmg.TFMGRegistries;
 import com.drmangotea.tfmg.base.lang.TFMGLang;
@@ -40,6 +39,7 @@ import net.neoforged.neoforge.fluids.FluidStack;
 import net.neoforged.neoforge.fluids.capability.IFluidHandler;
 import net.neoforged.neoforge.items.IItemHandler;
 import org.apache.commons.lang3.StringUtils;
+import org.joml.Quaterniond;
 
 import java.util.Arrays;
 import java.util.List;
@@ -47,15 +47,15 @@ import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 public class TFMGUtils {
-
     public static float toYRot(Direction facing) {
-        return switch (facing){
+        return switch (facing) {
             case DOWN, UP, NORTH -> 0.0F;
             case SOUTH -> 180F;
             case WEST -> 90;
             case EAST -> 270F;
         };
     }
+	
     public static void createFireExplosion(Level level, Entity entity, BlockPos pos, int sparkAmount, float radius) {
 
         if (level.isClientSide && entity != null) level.broadcastEntityEvent(entity, (byte) 3);
@@ -75,6 +75,7 @@ public class TFMGUtils {
         }
         level.explode(null, pos.getX(), pos.getY(), pos.getZ(), radius, Level.ExplosionInteraction.BLOCK);
     }
+	
     public static void playSound(Level level, BlockPos pos, SoundEvent sound, SoundSource source){
         playSound(level,pos,sound,source,1,1,null);
     }
@@ -89,7 +90,6 @@ public class TFMGUtils {
     }
 
     public static void blowUpTank(FluidTankBlockEntity tank, int power) {
-
         if (tank == null || tank.getControllerBE() == null) return;
         FluidTankBlockEntity be = tank.getControllerBE();
 
@@ -118,14 +118,14 @@ public class TFMGUtils {
     }
 
     public static String fromId(String key) {
-        String s = key.replaceAll("_", " ");
+        String s = key.replace("_", " ");
         s = Arrays.stream(StringUtils.splitByCharacterTypeCamelCase(s)).map(StringUtils::capitalize).collect(Collectors.joining(" "));
         s = StringUtils.normalizeSpace(s);
         return s;
     }
 
     public static String toHumanReadable(String key) {
-        String s = key.replaceAll("_", " ");
+        String s = key.replace("_", " ");
         s = Arrays.stream(StringUtils.splitByCharacterTypeCamelCase(s)).map(StringUtils::capitalize).collect(Collectors.joining(" "));
         s = StringUtils.normalizeSpace(s);
         return s;
@@ -160,6 +160,16 @@ public class TFMGUtils {
 
         return (float) Math.sqrt(x * x + z * z + (_2D?0:y*y));
     }
+	
+	//for Sable stuff:
+	public static Vec3 rotateQuat(final Vec3 V, final Quaterniond Q) {
+		final Quaterniond q = new Quaterniond((float) V.x, (float) V.y, (float) V.z, 0.0f);
+		final Quaterniond Q2 = new Quaterniond(Q);
+		q.mul(Q2);
+		Q2.conjugate();
+		Q2.mul(q);
+		return new Vec3(Q2.x(), Q2.y(), Q2.z());
+	}
 
     public static void createStorageTooltip(BlockEntity be, List<Component> tooltip) {
         createFluidTooltip(be, tooltip);

--- a/src/main/java/com/drmangotea/tfmg/content/machinery/oil_processing/surface_scanner/SurfaceScannerBlock.java
+++ b/src/main/java/com/drmangotea/tfmg/content/machinery/oil_processing/surface_scanner/SurfaceScannerBlock.java
@@ -1,22 +1,27 @@
 package com.drmangotea.tfmg.content.machinery.oil_processing.surface_scanner;
 
+import com.drmangotea.tfmg.TFMG;
 import com.drmangotea.tfmg.base.TFMGShapes;
 import com.drmangotea.tfmg.registry.TFMGBlockEntities;
 import com.simibubi.create.foundation.block.IBE;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.world.level.BlockGetter;
+import net.minecraft.world.level.SignalGetter;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.shapes.CollisionContext;
 import net.minecraft.world.phys.shapes.VoxelShape;
+import org.jetbrains.annotations.NotNull;
 
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
 import java.util.concurrent.atomic.AtomicInteger;
 
 public class SurfaceScannerBlock extends Block implements IBE<SurfaceScannerBlockEntity> {
-    public SurfaceScannerBlock(Properties p_49795_) {
-        super(p_49795_);
+    public SurfaceScannerBlock(Properties p) {
+        super(p);
     }
 
     @Override
@@ -24,25 +29,43 @@ public class SurfaceScannerBlock extends Block implements IBE<SurfaceScannerBloc
         return SurfaceScannerBlockEntity.class;
     }
 
-    @Override
-    public VoxelShape getShape(BlockState p_60555_, BlockGetter p_60556_, BlockPos p_60557_, CollisionContext p_60558_) {
+    @Override @NotNull @ParametersAreNonnullByDefault
+    public VoxelShape getShape(BlockState state, BlockGetter level, BlockPos pos, CollisionContext context) {
         return TFMGShapes.SLAB;
     }
-
+	
+	//TODO: Make the redstone work
+	@Override @ParametersAreNonnullByDefault
     public boolean isSignalSource(BlockState state) {
         return true;
     }
-
-    public int getSignal(BlockState blockState, BlockGetter blockAccess, BlockPos pos, Direction side) {
-        if (side.getAxis().isVertical()) {
+	
+	@Override @ParametersAreNonnullByDefault
+    public int getSignal(BlockState blockState, BlockGetter level, BlockPos pos, Direction side) {
+		if (side.getAxis().isVertical()) {
             return 0;
         }
         AtomicInteger signal = new AtomicInteger(0);
-        withBlockEntityDo(blockAccess, pos, (scanner) -> signal.set(scanner.getDirectionalSignal(side)));
-        return signal.get();
+        withBlockEntityDo(level, pos, (be) -> signal.set(be.getDirectionalSignal(side)));
+		return signal.get();
     }
-
-    @Override
+	
+	@Override @ParametersAreNonnullByDefault
+	protected int getDirectSignal(BlockState state, BlockGetter level, BlockPos pos, Direction side) {
+		return getSignal(state, level, pos, side);
+	}
+	
+	@Override @ParametersAreNonnullByDefault
+	public boolean shouldCheckWeakPower(final BlockState state, final SignalGetter level, final BlockPos pos, final Direction side) {
+		return false;
+	}
+	
+	@Override @ParametersAreNonnullByDefault
+	public boolean canConnectRedstone(final BlockState state, final BlockGetter level, final BlockPos pos, @Nullable final Direction direction) {
+		return !(direction == null || direction.getAxis().isVertical());
+	}
+	
+	@Override
     public BlockEntityType<? extends SurfaceScannerBlockEntity> getBlockEntityType() {
         return TFMGBlockEntities.SURFACE_SCANNER.get();
     }

--- a/src/main/java/com/drmangotea/tfmg/content/machinery/oil_processing/surface_scanner/SurfaceScannerBlockEntity.java
+++ b/src/main/java/com/drmangotea/tfmg/content/machinery/oil_processing/surface_scanner/SurfaceScannerBlockEntity.java
@@ -1,5 +1,7 @@
 package com.drmangotea.tfmg.content.machinery.oil_processing.surface_scanner;
 
+import com.drmangotea.tfmg.TFMG;
+import com.drmangotea.tfmg.base.TFMGUtils;
 import com.drmangotea.tfmg.base.lang.TFMGTexts;
 import com.drmangotea.tfmg.config.TFMGConfigs;
 import com.drmangotea.tfmg.content.machinery.misc.machine_input.MachineInputBlockEntity;
@@ -19,16 +21,17 @@ import net.minecraft.world.level.chunk.ChunkAccess;
 import net.minecraft.world.phys.AABB;
 
 import java.util.List;
+
+import net.minecraft.world.phys.Vec3;
 import org.joml.Quaterniond;
 
 public class SurfaceScannerBlockEntity extends SmartBlockEntity implements IHaveGoggleInformation {
-
     private long lastScanTick = Long.MIN_VALUE;
     private BlockPos lastScanPos = null;
-    private Quaterniond lastScanRot = new Quaterniond();
+	private Quaterniond lastScanRot = new Quaterniond();
+	private BlockPos nearestDeposit;
 
-    public Boolean[][] grid = new Boolean[5][5];
-    private final boolean[][] serverGrid = new boolean[5][5];
+    public boolean[][] grid = new boolean[5][5];
 
     public SurfaceScannerBlockEntity(BlockEntityType<?> type, BlockPos pos, BlockState state) {
         super(type, pos, state);
@@ -41,35 +44,58 @@ public class SurfaceScannerBlockEntity extends SmartBlockEntity implements IHave
     public void findDeposits() {
         if (level == null) return;
         if (!level.isClientSide) return;
+		
+		BlockPos actualPosition = SurfaceScannerSable.getActualPosition(this);
+		int scanDepth = TFMGConfigs.common().machines.surfaceScannerScanDepth.get();
 
-        for (int x = 0; x < 5; x++) {
-            for (int z = 0; z < 5; z++) {
-                grid[x][z] = hasOil(SurfaceScannerSable.evaluateOilPos(this, x, z));
-            }
-        }
+        for (int x = 0; x < 5; x++) { for (int z = 0; z < 5; z++) {
+			BlockPos pos = new BlockPos(
+				actualPosition.getX() + (x - 2) * 16,
+				scanDepth,
+				actualPosition.getZ() + (z - 2) * 16
+			);
+			boolean oil = hasOil(pos);
+			grid[x][z] = oil;
+			if (oil) {
+				if (nearestDeposit == null) {
+					nearestDeposit = pos;
+				} else {
+					float currentDistance = TFMGUtils.getDistance(actualPosition, nearestDeposit, true);
+					float newDistance = TFMGUtils.getDistance(actualPosition, pos, true);
+					if (newDistance < currentDistance) nearestDeposit = pos;
+				}
+			}
+		} }
+		
+		level.updateNeighborsAt(getBlockPos(), getBlockState().getBlock());
     }
+	
+	public boolean operational() {
+		return level != null
+			&& level.getBlockEntity(getBlockPos().below()) instanceof MachineInputBlockEntity input
+			&& Math.abs(input.getSpeed()) >= TFMGConfigs.common().machines.surfaceScannerMinimumRPM.get();
+	}
 
     @Override
     public boolean addToGoggleTooltip(List<Component> tooltip, boolean isPlayerSneaking) {
         TFMGTexts.header("surface_scanner")
                 .style(ChatFormatting.GRAY)
                 .forGoggles(tooltip);
-        if (level == null) return false;
-        boolean operational = level.getBlockEntity(getBlockPos().below()) instanceof MachineInputBlockEntity be && Math.abs(be.getSpeed()) >= TFMGConfigs.common().machines.industrialMixerMinimumRPM.get();
-        if(operational) {
+        if (operational()) {
             int depositsFound = 0;
-            for(Boolean[] row : grid){
-                for(Boolean light : row){
-                    if(light != null && light)
-                        depositsFound++;
-                }
-            }
-            if(depositsFound > 0){
+            for (boolean[] row : grid) { for (boolean light : row) {
+				if (light) depositsFound++;
+			} }
+            if (depositsFound > 0) {
                 TFMGTexts.SurfaceScanner.deposits(depositsFound).forGoggles(tooltip);
-            }else
-                TFMGTexts.SurfaceScanner.noDeposit().forGoggles(tooltip);
-        } else
-            TFMGTexts.CommonMachines.minRPM(TFMGConfigs.common().machines.surfaceScannerMinimumRPM.get()).style(ChatFormatting.DARK_RED).forGoggles(tooltip);
+				//add nearest deposit tooltip?
+            } else {
+				TFMGTexts.SurfaceScanner.noDeposit().forGoggles(tooltip);
+            }
+        } else {
+			TFMGTexts.CommonMachines.minRPM(TFMGConfigs.common().machines.surfaceScannerMinimumRPM.get())
+				.style(ChatFormatting.DARK_RED).forGoggles(tooltip);
+        }
         return true;
     }
 
@@ -78,10 +104,10 @@ public class SurfaceScannerBlockEntity extends SmartBlockEntity implements IHave
         super.lazyTick();
         if (level == null) return;
         BlockPos actualPosition = SurfaceScannerSable.getActualPosition(this);
-        if (level.getBlockEntity(getBlockPos().below()) instanceof MachineInputBlockEntity input && Math.abs(input.getSpeed()) >= TFMGConfigs.common().machines.surfaceScannerMinimumRPM.get()) {
+        if (operational()) {
             boolean moved = lastScanPos == null || !lastScanPos.equals(actualPosition);
             Quaterniond currentRot = SurfaceScannerSable.getSublevelRot(this);
-            boolean rotChanged = currentRot != lastScanRot;
+            boolean rotChanged = !currentRot.equals(lastScanRot);
             int intervalTicks = 2400;
             long currentTick = level != null ? level.getGameTime() : Long.MIN_VALUE;
             boolean intervalElapsed = lastScanTick == Long.MIN_VALUE || (currentTick - lastScanTick) >= intervalTicks;
@@ -91,25 +117,13 @@ public class SurfaceScannerBlockEntity extends SmartBlockEntity implements IHave
             }
 
             findDeposits();
-            if (level != null && !level.isClientSide) {
-                updateServerGrid();
-            }
             lastScanPos = actualPosition;
             lastScanTick = currentTick;
             lastScanRot = currentRot;
         } else {
-            grid = new Boolean[5][5];
+            grid = new boolean[5][5];
+			nearestDeposit = null;
         }
-    }
-
-    private void updateServerGrid() {
-        if (level == null) return;
-        for (int x = 0; x < 5; x++) {
-            for (int z = 0; z < 5; z++) {
-                serverGrid[x][z] = hasOil(SurfaceScannerSable.evaluateOilPos(this, x, z));
-            }
-        }
-        level.updateNeighborsAt(getBlockPos(), getBlockState().getBlock());
     }
 
     public boolean hasOil(BlockPos pos) {
@@ -117,43 +131,37 @@ public class SurfaceScannerBlockEntity extends SmartBlockEntity implements IHave
         ChunkAccess chunk = level.getChunk(pos);
         AABB checkedArea = new AABB(chunk.getPos().getMiddleBlockPosition(TFMGConfigs.common().machines.surfaceScannerScanDepth.get()).north().west());
         checkedArea = checkedArea.inflate(7,0,7);
-        for(BlockState state : chunk.getBlockStates(checkedArea).toList()){
+        for (BlockState state : chunk.getBlockStates(checkedArea).toList()) {
             if(state.is(TFMGTags.Blocks.SURFACE_SCANNER_FINDABLE.tag))
-                return true;
+				return true;
         }
         return false;
     }
 
-    public int getDirectionalSignal(Direction side) {
-        int bestDistance = Integer.MAX_VALUE;
-        for (int x = 0; x < 5; x++) {
-            for (int z = 0; z < 5; z++) {
-                if (!serverGrid[x][z]) {
-                    continue;
-                }
-                int dx = x - 2;
-                int dz = z - 2;
-                Direction cellDirection = dominantDirection(dx, dz);
-                if (cellDirection != null && cellDirection != side) {
-                    continue;
-                }
-                int distance = Math.max(Math.abs(dx), Math.abs(dz));
-                bestDistance = Math.min(bestDistance, distance);
-            }
-        }
-        if (bestDistance == Integer.MAX_VALUE) {
-            return 0;
-        }
-        return Math.max(1, 15 - bestDistance * 5);
-    }
-
-    private Direction dominantDirection(int dx, int dz) {
-        if (dx == 0 && dz == 0) {
-            return null;
-        }
-        if (Math.abs(dx) >= Math.abs(dz)) {
-            return dx > 0 ? Direction.WEST : Direction.EAST;
-        }
-        return dz > 0 ? Direction.NORTH : Direction.SOUTH;
-    }
+    public int getDirectionalSignal (Direction side) {
+		if (nearestDeposit == null) return 0;
+		//normalized direction vector:
+		Vec3 direction = switch (side) {
+			case DOWN, UP -> null;
+			case NORTH -> new Vec3(0, 0,  1);
+			case SOUTH -> new Vec3(0, 0, -1);
+			case WEST -> new Vec3( 1, 0,  0);
+			case EAST -> new Vec3(-1, 0,  0);
+		};
+		if (direction == null) return 0; //just in case
+		//direction rotated to sublevel orientation:
+		direction = TFMGUtils.rotateQuat(direction, lastScanRot.conjugate());
+		
+		Vec3 toNearest = Vec3.atCenterOf(lastScanPos).subtract(Vec3.atCenterOf(nearestDeposit));
+		//2d distance:
+		double dist = Math.sqrt(toNearest.x()*toNearest.x() + toNearest.z()*toNearest.z());
+		if (dist <= 2) return 0;
+		
+		//normalized vector towards nearest deposit:
+		toNearest =  new Vec3(toNearest.x() / dist, 0, toNearest.z() / dist);
+		
+		//cosine of the angle can be given by the dot product, since both are normalized
+		double cosine = toNearest.dot(direction);
+		return (int) Math.max(0, 30 * Math.asin(cosine) / Math.PI); //how Aero does it
+	}
 }

--- a/src/main/java/com/drmangotea/tfmg/content/machinery/oil_processing/surface_scanner/SurfaceScannerRenderer.java
+++ b/src/main/java/com/drmangotea/tfmg/content/machinery/oil_processing/surface_scanner/SurfaceScannerRenderer.java
@@ -1,7 +1,9 @@
 package com.drmangotea.tfmg.content.machinery.oil_processing.surface_scanner;
 
+import com.drmangotea.tfmg.integration.sable.SurfaceScannerSable;
 import com.drmangotea.tfmg.registry.TFMGPartialModels;
 import com.mojang.blaze3d.vertex.PoseStack;
+import com.mojang.blaze3d.vertex.VertexConsumer;
 import com.simibubi.create.foundation.blockEntity.renderer.SafeBlockEntityRenderer;
 import com.simibubi.create.foundation.render.RenderTypes;
 import net.createmod.catnip.render.CachedBuffers;
@@ -9,27 +11,49 @@ import net.minecraft.client.renderer.LightTexture;
 import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.client.renderer.blockentity.BlockEntityRendererProvider;
 import net.minecraft.world.level.block.state.BlockState;
+import org.joml.Quaterniond;
+import org.joml.Quaternionf;
 
 public class SurfaceScannerRenderer extends SafeBlockEntityRenderer<SurfaceScannerBlockEntity> {
-    public SurfaceScannerRenderer(BlockEntityRendererProvider.Context context) {
-
-    }
+	private static final Quaternionf
+		FACING_NORTH = new Quaternionf(0, 0, 0,  1).normalize(), //+z
+		FACING_WEST  = new Quaternionf(0, 1, 0,  1).normalize(), //+x
+		FACING_SOUTH = new Quaternionf(0, 1, 0,  0).normalize(), //-z
+		FACING_EAST  = new Quaternionf(0, 1, 0, -1).normalize(); //-x
+	
+    public SurfaceScannerRenderer(BlockEntityRendererProvider.Context context) {}
+	
+	private Quaternionf getFacingQuat (SurfaceScannerBlockEntity be) {
+		//I feel like there should be a way to optimise this further, but it works -Shallow
+		Quaterniond q1 = SurfaceScannerSable.getSublevelRot(be).conjugate();
+		Quaternionf q = new Quaternionf(0, q1.y, 0, q1.w).normalize();
+		float
+			north = q.dot(FACING_NORTH),
+			west = q.dot(FACING_WEST),
+			south = q.dot(FACING_SOUTH),
+			east = q.dot(FACING_EAST);
+		float dot = Math.min(Math.min(north,west),Math.min(south,east));
+		if (dot == north) return FACING_NORTH;
+		if (dot == west) return FACING_WEST;
+		if (dot == south) return FACING_SOUTH;
+		if (dot == east) return FACING_EAST;
+		return FACING_NORTH;
+	}
+	
     @Override
     protected void renderSafe(SurfaceScannerBlockEntity be, float partialTicks, PoseStack ms, MultiBufferSource bufferSource, int light, int overlay) {
         BlockState blockState = be.getBlockState();
+		VertexConsumer buffer = bufferSource.getBuffer(RenderTypes.additive());
         ms.pushPose();
-        for(int x = 0;x<5;x++) {
-            for (int z = 0; z < 5; z++) {
-
-                    if(be.grid[x][z]!=null && be.grid[x][z])
-                        CachedBuffers.partial(TFMGPartialModels.SURFACE_SCANNER_LIGHT, blockState)
-                                .translate((x - 2)*0.19, 0, (z - 2)*0.19)
-                                .light(LightTexture.FULL_BRIGHT)
-                                .color(255, 69, 96, 255)
-                                .renderInto(ms, bufferSource.getBuffer(RenderTypes.additive()));
-
-            }
-        }
+		ms.rotateAround(getFacingQuat(be), 0.5f, 0.5f, 0.5f);
+  
+		for(int x = 0;x<5;x++) { for (int z = 0; z < 5; z++) { if(be.grid[x][z]) {
+			CachedBuffers.partial(TFMGPartialModels.SURFACE_SCANNER_LIGHT, blockState)
+				.translate((x - 2)*0.19, 0, (z - 2)*0.19)
+				.light(LightTexture.FULL_BRIGHT)
+				.color(255, 69, 96, 255) //#ff4560ff
+				.renderInto(ms, buffer);
+		} } }
         ms.popPose();
     }
 }

--- a/src/main/java/com/drmangotea/tfmg/integration/sable/SurfaceScannerSable.java
+++ b/src/main/java/com/drmangotea/tfmg/integration/sable/SurfaceScannerSable.java
@@ -1,6 +1,5 @@
 package com.drmangotea.tfmg.integration.sable;
 
-import com.drmangotea.tfmg.config.TFMGConfigs;
 import com.drmangotea.tfmg.content.machinery.oil_processing.surface_scanner.SurfaceScannerBlockEntity;
 import dev.ryanhcode.sable.companion.SableCompanion;
 import dev.ryanhcode.sable.companion.SubLevelAccess;
@@ -8,7 +7,6 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.phys.Vec3;
 import org.joml.Quaterniond;
-import org.joml.Vector3d;
 
 import javax.annotation.Nullable;
 
@@ -18,38 +16,6 @@ public class SurfaceScannerSable {
     private static long cachedTick = Long.MIN_VALUE;
     @Nullable
     private static SubLevelAccess cachedSubLevel;
-
-    //Crazy?
-    //I was crazy once.
-    //They locked me in a room,
-    //A rubber room,
-    //A rubber room with math,
-    //The math made me crazy...
-    public static BlockPos evaluateOilPos(SurfaceScannerBlockEntity scanner, int x, int z) {
-        BlockPos actualPosition = getActualPosition(scanner);
-        Quaterniond rot = SurfaceScannerSable.getSublevelRot(scanner);
-        int scanDepth = TFMGConfigs.common().machines.surfaceScannerScanDepth.get();
-        int cx = x - 2;
-        int cz = z - 2;
-        Vector3d chunkOffset = new Vector3d(cx, 0.0, cz);
-
-        if (rot != null) rot.transform(chunkOffset);
-
-        int rx = (int) Math.round(chunkOffset.x);
-        int rz = (int) Math.round(chunkOffset.z);
-
-        if (Math.abs(Math.abs(chunkOffset.x) - Math.abs(chunkOffset.z)) < 0.5) {
-            int mag = (int) Math.round((Math.abs(chunkOffset.x) + Math.abs(chunkOffset.z)) / 2.0);
-            rx = (int) Math.copySign(mag, chunkOffset.x);
-            rz = (int) Math.copySign(mag, chunkOffset.z);
-        }
-
-        return new BlockPos(
-                actualPosition.getX() + rx * 16,
-                scanDepth,
-                actualPosition.getZ() + rz * 16
-        );
-    }
 
     public static BlockPos getActualPosition(SurfaceScannerBlockEntity scanner) {
         BlockPos scannerPos = scanner.getBlockPos();
@@ -63,11 +29,8 @@ public class SurfaceScannerSable {
 
     public static Quaterniond getSublevelRot(SurfaceScannerBlockEntity scanner) {
         SubLevelAccess subLevel = getScannerSubLevel(scanner);
-        Quaterniond rot = new Quaterniond();
-        if (subLevel != null) {
-            rot = new Quaterniond(subLevel.logicalPose().orientation());
-        }
-        return rot;
+        if (subLevel == null) return new Quaterniond();
+		return new Quaterniond(subLevel.logicalPose().orientation());
     }
 
     @Nullable


### PR DESCRIPTION
- returned scanning to global north-oriented grid
- rotate rendered lights to always approximatley point in the right direction
  - it's slow to update during big changes, not sure why exactly that is
- cool math for redstone signal, but redstone signal is broken :/
- added rotateQuat method in TFMGUtils

I cannot figure out the redstone. I took a look at Aero's Navigation Table code and tried copying what it was doing, but that didn't work.