### PR TITLE
fixed inconsistencies in flarestacks, smokestacks, and exhaust

### DIFF
--- a/src/main/java/com/drmangotea/tfmg/content/machinery/misc/exhaust/ExhaustBlockEntity.java
+++ b/src/main/java/com/drmangotea/tfmg/content/machinery/misc/exhaust/ExhaustBlockEntity.java
@@ -97,11 +97,10 @@ public class ExhaustBlockEntity extends SmartBlockEntity implements IHaveGoggleI
         if(tankInventory.getFluidAmount() > 0) {
             smokeTimer = 100;
             spawnsSmoke = true;
+            tankInventory.drain(50, IFluidHandler.FluidAction.EXECUTE);
         }
 
-        if (tankInventory.getSpace() > 700) {
-            tankInventory.drain(100, IFluidHandler.FluidAction.EXECUTE);
-        } else tankInventory.drain(10, IFluidHandler.FluidAction.EXECUTE);
+
     }
 
 

--- a/src/main/java/com/drmangotea/tfmg/content/machinery/misc/flarestack/FlarestackBlockEntity.java
+++ b/src/main/java/com/drmangotea/tfmg/content/machinery/misc/flarestack/FlarestackBlockEntity.java
@@ -85,12 +85,9 @@ public class FlarestackBlockEntity extends SmartBlockEntity implements IHaveGogg
             return;
         }
 
-        if (tankInventory.getFluidAmount() > 0 && smokeTimer < 96) {
-            if(tankInventory.getFluidAmount() > 1000) {
-                tankInventory.drain(100, IFluidHandler.FluidAction.EXECUTE);
-            } else
-                tankInventory.drain(30, IFluidHandler.FluidAction.EXECUTE);
+        if (tankInventory.getFluidAmount() > 0) {
             smokeTimer = 100;
+            tankInventory.drain(25, IFluidHandler.FluidAction.EXECUTE);
         }
 
         if (smokeTimer > 0) {

--- a/src/main/java/com/drmangotea/tfmg/content/machinery/misc/smokestack/SmokestackBlockEntity.java
+++ b/src/main/java/com/drmangotea/tfmg/content/machinery/misc/smokestack/SmokestackBlockEntity.java
@@ -96,7 +96,7 @@ public class SmokestackBlockEntity extends SmartBlockEntity {
             return;
 
         if (getBlockState().getValue(TOP)) {
-            tankInventory.drain(tankInventory.getSpace() < 1000 ? 50 : 10, IFluidHandler.FluidAction.EXECUTE);
+            tankInventory.drain(100, IFluidHandler.FluidAction.EXECUTE);
             smokeTimer = 40;
         }
 


### PR DESCRIPTION
removed the part where if the internal fluid tank was filled past a certain amount the smokestack and exhaust would drain slower, removed the part where the flarestack only drains every 4 ticks (divided the base value by 4 as well,) and swapped the drain values for the smokestack and the exhaust so the smokestack drains more CO2 per tick.

imo it would be worth it to remove the drain rate entirely from the smokestack, and just empty the smokestack every tick it has fluid in it so that it's on par with just having a pipe output CO2 to the air, but i didn't do that here.